### PR TITLE
Path monitor scrolling, window ladder, and a README split

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1608,7 +1608,7 @@ dependencies = [
 
 [[package]]
 name = "octomon"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "octomon"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 description = "Btop-style terminal network monitor: latency, bandwidth, and Wi-Fi signal"
 repository = "https://github.com/securitypedant/octomon"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ rust-version = "1.88"
 include = [
     "src/**/*.rs",
     "README.md",
+    "PRIVILEGES.md",
     "LICENSE-MIT",
     "LICENSE-APACHE",
     "SECURITY.md",

--- a/PRIVILEGES.md
+++ b/PRIVILEGES.md
@@ -1,0 +1,160 @@
+# Privileges
+
+octomon is built to run without elevation, and says at startup what that costs
+on the machine you are on. It never asks for a password and never refuses to
+start; where a measurement genuinely needs privilege, the affected panel says
+so rather than the whole tool gating itself behind a prompt.
+
+What that means in practice differs sharply by platform, so the detail is here
+rather than cluttering the [README](README.md).
+
+| Platform | Unprivileged | To get everything |
+|---|---|---|
+| macOS | everything | nothing to do |
+| Linux | latency often needs a one-line sysctl; per-process bandwidth sees only your own processes | open the ping-socket range once, and `sudo octomon` for the full process view |
+| Windows | everything except per-process bandwidth | join Performance Log Users once |
+
+## Why octomon runs unprivileged
+
+octomon never asks for `sudo`, and that is a deliberate design constraint rather
+than an accident of what was easy to build.
+
+A network monitor is exactly the kind of tool you reach for when something is
+already wrong — often on a machine that isn't yours, or a work laptop where you
+don't have admin, or over SSH on a box you'd rather not escalate on. A tool that
+demands root at that moment is a tool you don't run. Requiring privilege also
+changes what the tool *is*: a root process that opens raw sockets and reads every
+process's traffic is a much larger thing to trust, needs a much closer audit, and
+turns a diagnostic you run casually into a decision you have to think about.
+
+So the rule is: if a measurement can only be had with elevated privilege, octomon
+does without it and says so, rather than gating the whole tool behind a password
+prompt. On [macOS](#macos) this costs nothing — every panel populates without
+root.
+
+Linux is where the principle meets its limits, and it is worth being blunt about
+it: unprivileged ICMP depends on a sysctl that distributions often ship closed,
+and per-process bandwidth genuinely cannot see other users' sockets without
+root. octomon still runs, still tells you exactly what is degraded and why, and
+never silently pretends — but `sudo octomon` is the honest recommendation there.
+See [Linux](#linux).
+
+Windows sits between the two. Everything except per-process bandwidth is
+unprivileged, and that one panel needs an ETW session — but the rights to open
+one can be granted *once*, by joining Performance Log Users, rather than
+re-elevating every run. That fits the rule better than `sudo` does: the elevated
+capability is a property of the account, not of the process you launch. See
+[Windows](#windows).
+
+## macOS
+
+Nothing to do. Latency uses unprivileged datagram ICMP, path discovery uses
+UDP-probe `traceroute`, per-process bandwidth uses `nettop`, and Wi-Fi comes
+from CoreWLAN and `system_profiler`. Every panel populates without root.
+
+Two limits are worth knowing, and neither is fixed by `sudo`: `nettop` reports
+only your own processes, and it is TCP-only, so QUIC and HTTP/3 traffic is not
+attributed. Neighbouring-network SSIDs additionally need Location Services;
+without it macOS redacts them, so airspace congestion counts networks per
+channel but cannot weight them by signal.
+
+## Linux
+
+**The short version: run `sudo octomon` on Linux.** Two things are narrower or
+broken without it, and only one of them can be fixed by configuration.
+
+| Feature | Unprivileged | With `sudo` |
+|---|---|---|
+| Latency, path monitor, traceroute targets | Broken on many distributions, fixable — see below | Works |
+| Per-process bandwidth | Your own processes only | Every process |
+| Everything else | Works | Works |
+
+octomon starts by telling you which of these apply on your machine.
+
+**ICMP.** Latency uses *unprivileged ping sockets* rather than raw sockets, so
+in principle no root is needed — but that depends on `net.ipv4.ping_group_range`,
+which several distributions (Ubuntu among them) ship closed. If Connection
+Quality stays empty and adding a target reports "ICMP unavailable", that is why.
+Fix it once, for everyone, which is what macOS does by default:
+
+```sh
+sudo sysctl -w net.ipv4.ping_group_range="0 2147483647"
+# persist across reboots
+echo 'net.ipv4.ping_group_range=0 2147483647' | sudo tee /etc/sysctl.d/99-ping.conf
+```
+
+Or grant the capability to the binary alone:
+
+```sh
+sudo setcap cap_net_raw+ep "$(which octomon)"
+```
+
+**Per-process bandwidth.** This one has no unprivileged workaround. `ss` cannot
+report other users' sockets without root, so unprivileged octomon sees only your
+own processes — system daemons and anything running as another user are simply
+invisible. Note that `ss` is also TCP-only regardless of privileges: QUIC and
+HTTP/3 traffic, which is much of modern browsing, carries no per-socket byte
+counters and cannot be attributed at all. (Windows is the exception here: its
+ETW provider does report UDP — see
+[Windows](#windows).)
+
+So: fix the sysctl and run as yourself if you mainly care about latency and the
+path monitor; use `sudo` if you want the full picture.
+
+## Windows
+
+Everything except per-process bandwidth works unprivileged. That one panel
+needs an ETW session on `Microsoft-Windows-Kernel-Network` — the provider Task
+Manager's own Network column reads — and Windows gates opening one.
+
+| Feature | Unprivileged | With the ETW session |
+|---|---|---|
+| Latency, path monitor, DNS, throughput, vitals | full | full |
+| Wi-Fi signal, channel, tx rate | full | full |
+| Neighbouring networks / airspace congestion | needs Location services on | same |
+| Per-process bandwidth | unavailable | full, **including QUIC and HTTP/3** |
+
+There are two ways to get it, and the first is better:
+
+```powershell
+# Add yourself to Performance Log Users once, then sign out and back in.
+net localgroup "Performance Log Users" "%USERNAME%" /add
+```
+
+After that octomon attributes traffic per process every run, unelevated. The
+alternative is to start it from an elevated terminal, which works but has to be
+done every time.
+
+This is the one place Windows is *ahead* of the other platforms. Linux's `ss`
+and macOS's `nettop` are both TCP-only, so QUIC and HTTP/3 — much of modern
+browsing — cannot be attributed there at all. The ETW provider reports UDP too,
+so an elevated Windows build sees traffic the others structurally cannot.
+
+Wi-Fi neighbour scanning is a separate matter: it needs **Location services**
+enabled (Settings → Privacy & security → Location), which is Windows' own
+restriction on `WlanGetNetworkBssList`, not a privilege question. Without it the
+signal reading falls back from the beacon's exact dBm to Windows' documented
+quality-percentage mapping, and the congestion view goes quiet.
+
+## What privileges would unlock
+
+
+We may add an *optional* privileged mode later — strictly opt-in, never required,
+and never the default. These are the things currently left on the table, and what
+each would need:
+
+| Capability | Needs | What it would add |
+|---|---|---|
+| Packet capture (BPF / libpcap) | root or BPF device access | Latency and loss of your *real* traffic instead of synthetic probes; per-flow and per-connection breakdown; DNS timing measured from actual queries rather than a probe |
+| System-wide per-process attribution (macOS, Linux) | root | `nettop` and `ss` only report the current user's processes, so traffic from system daemons and other users is missing today. Windows already has this via ETW |
+| Live per-process sampling | root / NetworkExtension entitlement | `nettop -L 1` takes ~5s per sample, which is why the Processes list updates slowly |
+| Which process owns a tunnel | root | `lsof` exposes `utun` ownership, but only for root-owned VPN daemons — so VPNs are identified from the tunnel's address ranges instead |
+| Neighbour SSIDs and their signal strength | Location Services permission | macOS redacts SSIDs without it, so airspace congestion counts networks per channel but cannot weight them by how loud each one is |
+| True channel airtime utilisation | root (monitor mode) | Counting nearby APs approximates congestion; measuring actual airtime busy-ratio would quantify it — but monitor mode disassociates the radio |
+| Raw sockets | root | ICMP traceroute rather than UDP probes, DSCP/ToS-marked probes to measure per-class queuing, and path-MTU discovery with the DF bit |
+| eBPF socket tracing (Linux) | `CAP_BPF` / root | Per-socket retransmits and latency attributed to the owning process, without sampling |
+| System-wide TCP state (Linux) | root | `/proc/net/tcp` and `ss` show your own sockets unprivileged; everything else needs elevation |
+
+If any of this lands, it will be behind an explicit flag, will degrade cleanly to
+the unprivileged path when it isn't available, and the unprivileged build will
+stay fully functional on its own.

--- a/README.md
+++ b/README.md
@@ -232,6 +232,17 @@ The binary is unsigned, so SmartScreen will warn on first run until the release
 builds reputation. Windows Terminal is recommended over the legacy console —
 the box-drawing characters and glyphs render correctly there without fiddling.
 
+If the charts come out as rows of empty boxes, the console is using a font with
+no braille glyphs — the raster fonts legacy `conhost` still defaults to have
+none, and note that an elevated window keeps its own font setting separately
+from an ordinary one. Either switch the font to Consolas or Cascadia Mono, or
+plot with block glyphs instead by setting this in
+`%APPDATA%\octomon\config.toml`:
+
+```toml
+graph_marker = "halfblock"
+```
+
 Read [Windows: privileges](#windows-privileges) if you want the per-process
 bandwidth panel.
 

--- a/README.md
+++ b/README.md
@@ -12,12 +12,9 @@ network, the Wi-Fi, the ISP, or your own machine that's misbehaving.
 
 ## What it shows
 
-Four panels, all updating live. On macOS everything works unprivileged. On
-Linux, plain `sudo octomon` is the path of least resistance — see
-[Linux: privileges](#linux-privileges) for what needs it and why, and how to
-avoid it if you would rather. On Windows everything works unprivileged except
-per-process bandwidth, which is a one-time group membership away — see
-[Windows: privileges](#windows-privileges):
+Four panels, all updating live. Everything below works unprivileged on macOS;
+Linux and Windows each hold one thing back, covered in
+[Privileges](#privileges).
 
 - **Connection Quality** — ICMP latency to configurable targets with a full
   distribution (last / avg / p95 / max), **jitter**, **packet loss**, and a
@@ -60,14 +57,14 @@ data that pivots straight into pandas, Excel or Grafana.
   Note that `ss` covers **TCP only** — UDP and QUIC traffic (much of modern
   browsing) carries no per-socket byte counters and cannot be attributed — and
   only your own processes unless run as root (see
-  [Linux: privileges](#linux-privileges)).
+  [privileges: Linux](PRIVILEGES.md#linux)).
 - **Windows** — supported. Wi-Fi (signal, channel, airspace congestion) comes
   from the Native Wifi API rather than parsing `netsh`, whose field *names* are
   translated on a non-English install. Path discovery uses the built-in
   `tracert`. Power source comes from `GetSystemPowerStatus`; there is no
   thermal-throttle verdict to read, and no load average, so neither is shown.
   Per-process bandwidth needs privilege — see
-  [Windows: privileges](#windows-privileges) — but it is the *only* platform
+  [privileges: Windows](PRIVILEGES.md#windows) — but it is the *only* platform
   where it covers QUIC and HTTP/3.
 
 ### Linux: external tools
@@ -94,83 +91,19 @@ Everything else degrades to "unavailable" rather than failing, and octomon tells
 you at startup what is missing and which package provides it. Live Wi-Fi signal
 reads `/proc/net/wireless` directly and needs no package at all.
 
-### Linux: privileges
+## Privileges
 
-**The short version: run `sudo octomon` on Linux.** Two things are narrower or
-broken without it, and only one of them can be fixed by configuration.
+octomon runs unprivileged by design, and tells you at startup what that costs on
+your machine. The short version:
 
-| Feature | Unprivileged | With `sudo` |
+| Platform | Unprivileged | To get everything |
 |---|---|---|
-| Latency, path monitor, traceroute targets | Broken on many distributions, fixable — see below | Works |
-| Per-process bandwidth | Your own processes only | Every process |
-| Everything else | Works | Works |
+| macOS | everything | nothing to do |
+| Linux | latency often needs a one-line sysctl; per-process bandwidth sees only your own processes | open the ping-socket range once, and `sudo octomon` for the full process view |
+| Windows | everything except per-process bandwidth | join Performance Log Users once |
 
-octomon starts by telling you which of these apply on your machine.
-
-**ICMP.** Latency uses *unprivileged ping sockets* rather than raw sockets, so
-in principle no root is needed — but that depends on `net.ipv4.ping_group_range`,
-which several distributions (Ubuntu among them) ship closed. If Connection
-Quality stays empty and adding a target reports "ICMP unavailable", that is why.
-Fix it once, for everyone, which is what macOS does by default:
-
-```sh
-sudo sysctl -w net.ipv4.ping_group_range="0 2147483647"
-# persist across reboots
-echo 'net.ipv4.ping_group_range=0 2147483647' | sudo tee /etc/sysctl.d/99-ping.conf
-```
-
-Or grant the capability to the binary alone:
-
-```sh
-sudo setcap cap_net_raw+ep "$(which octomon)"
-```
-
-**Per-process bandwidth.** This one has no unprivileged workaround. `ss` cannot
-report other users' sockets without root, so unprivileged octomon sees only your
-own processes — system daemons and anything running as another user are simply
-invisible. Note that `ss` is also TCP-only regardless of privileges: QUIC and
-HTTP/3 traffic, which is much of modern browsing, carries no per-socket byte
-counters and cannot be attributed at all. (Windows is the exception here: its
-ETW provider does report UDP — see
-[Windows: privileges](#windows-privileges).)
-
-So: fix the sysctl and run as yourself if you mainly care about latency and the
-path monitor; use `sudo` if you want the full picture.
-
-### Windows: privileges
-
-Everything except per-process bandwidth works unprivileged. That one panel
-needs an ETW session on `Microsoft-Windows-Kernel-Network` — the provider Task
-Manager's own Network column reads — and Windows gates opening one.
-
-| Feature | Unprivileged | With the ETW session |
-|---|---|---|
-| Latency, path monitor, DNS, throughput, vitals | full | full |
-| Wi-Fi signal, channel, tx rate | full | full |
-| Neighbouring networks / airspace congestion | needs Location services on | same |
-| Per-process bandwidth | unavailable | full, **including QUIC and HTTP/3** |
-
-There are two ways to get it, and the first is better:
-
-```powershell
-# Add yourself to Performance Log Users once, then sign out and back in.
-net localgroup "Performance Log Users" "%USERNAME%" /add
-```
-
-After that octomon attributes traffic per process every run, unelevated. The
-alternative is to start it from an elevated terminal, which works but has to be
-done every time.
-
-This is the one place Windows is *ahead* of the other platforms. Linux's `ss`
-and macOS's `nettop` are both TCP-only, so QUIC and HTTP/3 — much of modern
-browsing — cannot be attributed there at all. The ETW provider reports UDP too,
-so an elevated Windows build sees traffic the others structurally cannot.
-
-Wi-Fi neighbour scanning is a separate matter: it needs **Location services**
-enabled (Settings → Privacy & security → Location), which is Windows' own
-restriction on `WlanGetNetworkBssList`, not a privilege question. Without it the
-signal reading falls back from the beacon's exact dBm to Windows' documented
-quality-percentage mapping, and the congestion view goes quiet.
+Per-platform detail, the exact commands, and the reasoning behind the design:
+**[PRIVILEGES.md](PRIVILEGES.md)**.
 
 ## Install
 
@@ -208,7 +141,7 @@ sudo install -m755 octomon /usr/local/bin/octomon
 
 Install `traceroute` as well if your distribution omits it — see
 [Linux: external tools](#linux-external-tools) — and read
-[Linux: privileges](#linux-privileges): on Linux you will most likely want to
+[privileges: Linux](PRIVILEGES.md#linux): on Linux you will most likely want to
 run `sudo octomon`.
 
 ### Windows
@@ -243,7 +176,7 @@ plot with block glyphs instead by setting this in
 graph_marker = "halfblock"
 ```
 
-Read [Windows: privileges](#windows-privileges) if you want the per-process
+Read [privileges: Windows](PRIVILEGES.md#windows) if you want the per-process
 bandwidth panel.
 
 ### crates.io (any platform)
@@ -345,62 +278,6 @@ never stalls the UI. Latency uses unprivileged datagram ICMP (`surge-ping`);
 per-process bandwidth reads `nettop`; Wi-Fi signal reads CoreWLAN directly; the
 rest comes from `sysinfo` and `netdev`. Latency is validated to match the
 system `ping`, so the jitter you see is the network's, not the tool's.
-
-## Why everything runs unprivileged
-
-octomon never asks for `sudo`, and that is a deliberate design constraint rather
-than an accident of what was easy to build.
-
-A network monitor is exactly the kind of tool you reach for when something is
-already wrong — often on a machine that isn't yours, or a work laptop where you
-don't have admin, or over SSH on a box you'd rather not escalate on. A tool that
-demands root at that moment is a tool you don't run. Requiring privilege also
-changes what the tool *is*: a root process that opens raw sockets and reads every
-process's traffic is a much larger thing to trust, needs a much closer audit, and
-turns a diagnostic you run casually into a decision you have to think about.
-
-So the rule is: if a measurement can only be had with elevated privilege, octomon
-does without it and says so, rather than gating the whole tool behind a password
-prompt. On macOS this costs nothing — latency uses unprivileged datagram ICMP
-(`SOCK_DGRAM`), path discovery uses UDP-probe `traceroute`, per-process bandwidth
-uses `nettop`, and Wi-Fi comes from CoreWLAN and `system_profiler`. Every panel
-is fully populated without root.
-
-Linux is where the principle meets its limits, and it is worth being blunt about
-it: unprivileged ICMP depends on a sysctl that distributions often ship closed,
-and per-process bandwidth genuinely cannot see other users' sockets without
-root. octomon still runs, still tells you exactly what is degraded and why, and
-never silently pretends — but `sudo octomon` is the honest recommendation there.
-See [Linux: privileges](#linux-privileges).
-
-Windows sits between the two. Everything except per-process bandwidth is
-unprivileged, and that one panel needs an ETW session — but the rights to open
-one can be granted *once*, by joining Performance Log Users, rather than
-re-elevating every run. That fits the rule better than `sudo` does: the elevated
-capability is a property of the account, not of the process you launch. See
-[Windows: privileges](#windows-privileges).
-
-### What privileges would unlock
-
-We may add an *optional* privileged mode later — strictly opt-in, never required,
-and never the default. These are the things currently left on the table, and what
-each would need:
-
-| Capability | Needs | What it would add |
-|---|---|---|
-| Packet capture (BPF / libpcap) | root or BPF device access | Latency and loss of your *real* traffic instead of synthetic probes; per-flow and per-connection breakdown; DNS timing measured from actual queries rather than a probe |
-| System-wide per-process attribution (macOS, Linux) | root | `nettop` and `ss` only report the current user's processes, so traffic from system daemons and other users is missing today. Windows already has this via ETW |
-| Live per-process sampling | root / NetworkExtension entitlement | `nettop -L 1` takes ~5s per sample, which is why the Processes list updates slowly |
-| Which process owns a tunnel | root | `lsof` exposes `utun` ownership, but only for root-owned VPN daemons — so VPNs are identified from the tunnel's address ranges instead |
-| Neighbour SSIDs and their signal strength | Location Services permission | macOS redacts SSIDs without it, so airspace congestion counts networks per channel but cannot weight them by how loud each one is |
-| True channel airtime utilisation | root (monitor mode) | Counting nearby APs approximates congestion; measuring actual airtime busy-ratio would quantify it — but monitor mode disassociates the radio |
-| Raw sockets | root | ICMP traceroute rather than UDP probes, DSCP/ToS-marked probes to measure per-class queuing, and path-MTU discovery with the DF bit |
-| eBPF socket tracing (Linux) | `CAP_BPF` / root | Per-socket retransmits and latency attributed to the owning process, without sampling |
-| System-wide TCP state (Linux) | root | `/proc/net/tcp` and `ss` show your own sockets unprivileged; everything else needs elevation |
-
-If any of this lands, it will be behind an explicit flag, will degrade cleanly to
-the unprivileged path when it isn't available, and the unprivileged build will
-stay fully functional on its own.
 
 ## Network & privacy
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -98,7 +98,7 @@ impl TargetStat {
             sent: 0,
             recv: 0,
             window: VecDeque::with_capacity(WINDOW),
-            history: History::new(1000),
+            history: History::new(HISTORY),
         }
     }
 
@@ -193,6 +193,10 @@ impl TargetStat {
 }
 
 const WINDOW: usize = 100;
+
+/// Latency samples kept per target. Bounds memory, and with it the longest
+/// window the statistics can actually cover — see [`AppState::window_samples`].
+const HISTORY: usize = 1000;
 
 /// Aggregate interface throughput (bytes/sec) plus history for charts.
 #[derive(Clone, Default)]
@@ -757,15 +761,43 @@ mod tests {
     }
 
     #[test]
-    fn window_cycles_30_60_300() {
+    fn the_window_ladder_only_ever_widens() {
         let mut s = AppState::new(vec![]);
         assert_eq!(s.window_secs, 60);
         s.cycle_window();
         assert_eq!(s.window_secs, 300);
         s.cycle_window();
-        assert_eq!(s.window_secs, 30);
+        assert_eq!(s.window_secs, 900);
+        // Wraps back to the start rather than stepping down mid-cycle.
         s.cycle_window();
         assert_eq!(s.window_secs, 60);
+    }
+
+    #[test]
+    fn the_window_cannot_claim_more_history_than_is_kept() {
+        let mut s = AppState::new(vec![]);
+        // One sample a second: the whole ladder fits inside the buffer.
+        s.samples_per_sec = 1.0;
+        s.window_secs = 900;
+        assert_eq!(s.window_samples(), 900);
+        assert!(!s.window_is_capped());
+
+        // Four a second is what --ping-interval 250 gives, and 900s of that is
+        // 3600 samples — far more than a target keeps.
+        s.samples_per_sec = 4.0;
+        assert_eq!(s.window_samples(), HISTORY);
+        assert!(s.window_is_capped(), "the UI has to be able to say so");
+    }
+
+    #[test]
+    fn the_window_label_reads_in_minutes() {
+        let mut s = AppState::new(vec![]);
+        s.window_secs = 60;
+        assert_eq!(s.window_label(), "1m");
+        s.window_secs = 900;
+        assert_eq!(s.window_label(), "15m");
+        s.window_secs = 45;
+        assert_eq!(s.window_label(), "45s");
     }
 
     #[test]
@@ -1077,17 +1109,49 @@ impl AppState {
         )
     }
 
-    /// Number of recent samples covered by the current window.
+    /// Number of recent samples the current window covers.
+    ///
+    /// Clamped to what a target actually keeps. Asking for more than the ring
+    /// holds silently returns fewer, which would leave the "window 5m" label
+    /// overstating the figures beneath it. A faster `--ping-interval` outruns
+    /// the buffer easily: 300s at 4 samples/sec wants 1200.
     pub fn window_samples(&self) -> usize {
+        self.window_samples_wanted().min(HISTORY)
+    }
+
+    /// Samples the window asks for, before the buffer limit applies.
+    fn window_samples_wanted(&self) -> usize {
         ((self.window_secs as f64 * self.samples_per_sec).round() as usize).max(1)
     }
 
-    /// Cycle the stats window: 30s → 60s → 300s → 30s.
+    /// True when the buffer, not the chosen window, decides how far back the
+    /// statistics reach — so the UI can say so instead of quietly misleading.
+    pub fn window_is_capped(&self) -> bool {
+        self.window_samples_wanted() > HISTORY
+    }
+
+    /// The window as a short label: "60s" becomes "1m".
+    pub fn window_label(&self) -> String {
+        if self.window_secs >= 60 && self.window_secs.is_multiple_of(60) {
+            format!("{}m", self.window_secs / 60)
+        } else {
+            format!("{}s", self.window_secs)
+        }
+    }
+
+    /// Cycle the stats window: 1m → 5m → 15m → 1m.
+    ///
+    /// Ascending, so repeated presses go one direction rather than widening
+    /// twice and then snapping narrower. Each stop is several times the last:
+    /// neighbouring windows that differ by 2x produce near-identical averages,
+    /// which wastes a stop. Nothing shorter than a minute, because p95 over a
+    /// few dozen samples is just "second worst" and jumps on any single spike;
+    /// `last` already covers the immediate picture.
     pub fn cycle_window(&mut self) {
         self.window_secs = match self.window_secs {
-            w if w < 60 => 60,
             w if w < 300 => 300,
-            _ => 30,
+            w if w < 900 => 900,
+            _ => 60,
         };
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -947,6 +947,9 @@ pub struct AppState {
     pub window_secs: u64,
     /// Samples per second (1000 / ping interval); converts window to samples.
     pub samples_per_sec: f64,
+    /// Glyphs the charts plot with. Carried here because a legacy Windows
+    /// console has no braille glyphs and draws every point as an empty box.
+    pub graph_marker: ratatui::symbols::Marker,
     /// Column cursor over the target table (0=target,1=last,2=avg,3=p95,4=max,5=loss).
     pub q_col: usize,
     /// Active target sort: (column, descending). None = insertion order.
@@ -1021,6 +1024,7 @@ impl AppState {
             graph_target: 0,
             window_secs: 60,
             samples_per_sec: 1.0,
+            graph_marker: ratatui::symbols::Marker::Braille,
             q_col: 0,
             q_sort: None,
             traceroute: None,

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,6 +9,7 @@ use std::net::IpAddr;
 use std::path::PathBuf;
 use std::time::Duration;
 
+use ratatui::symbols::Marker;
 use serde::{Deserialize, Serialize};
 
 /// A single ICMP target.
@@ -59,6 +60,14 @@ pub struct Config {
     /// Name looked up when probing resolvers. A widely cached name measures what
     /// applications actually experience; something obscure measures recursion.
     pub dns_probe_name: String,
+    /// Glyphs used to plot chart lines: "braille", "halfblock" or "dot".
+    ///
+    /// Braille packs 2x4 dots into one cell and is what the charts are drawn
+    /// around, but those glyphs are missing from the raster fonts a legacy
+    /// Windows console still defaults to, where every plotted point comes out
+    /// as an empty box. "halfblock" gives up half the vertical resolution for
+    /// glyphs that render essentially anywhere.
+    pub graph_marker: String,
 }
 
 impl Default for Config {
@@ -87,6 +96,7 @@ impl Default for Config {
             dns_interval_ms: 5000,
             dns_timeout_ms: 2000,
             dns_probe_name: "example.com".to_string(),
+            graph_marker: "braille".to_string(),
         }
     }
 }
@@ -118,6 +128,18 @@ impl Config {
     }
     pub fn dns_timeout(&self) -> Duration {
         Duration::from_millis(self.dns_timeout_ms.max(100))
+    }
+
+    /// Chart marker, falling back to braille for an unrecognised value rather
+    /// than refusing to start over a cosmetic setting.
+    pub fn marker(&self) -> Marker {
+        match self.graph_marker.trim().to_ascii_lowercase().as_str() {
+            "halfblock" | "half_block" | "half-block" => Marker::HalfBlock,
+            "dot" => Marker::Dot,
+            "block" => Marker::Block,
+            "bar" => Marker::Bar,
+            _ => Marker::Braille,
+        }
     }
 
     /// The config file path.
@@ -213,5 +235,21 @@ mod path_tests {
     fn the_config_file_sits_in_the_config_directory() {
         let dir = Config::dir().expect("a home directory");
         assert!(Config::path().unwrap().starts_with(&dir));
+    }
+
+    #[test]
+    fn the_graph_marker_falls_back_rather_than_failing() {
+        let with = |v: &str| Config {
+            graph_marker: v.to_string(),
+            ..Config::default()
+        };
+        assert_eq!(Config::default().marker(), Marker::Braille);
+        assert_eq!(with("halfblock").marker(), Marker::HalfBlock);
+        assert_eq!(with("HalfBlock").marker(), Marker::HalfBlock);
+        assert_eq!(with("half-block").marker(), Marker::HalfBlock);
+        assert_eq!(with(" dot ").marker(), Marker::Dot);
+        // A typo in a cosmetic setting must not stop octomon starting.
+        assert_eq!(with("brailel").marker(), Marker::Braille);
+        assert_eq!(with("").marker(), Marker::Braille);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -719,7 +719,7 @@ async fn add_target(state: Arc<Mutex<AppState>>, client: Arc<Client>, cfg: Confi
 fn print_snapshot(s: &AppState) {
     println!("== octomon --check ==");
     let n = s.window_samples();
-    println!("\n[Connection Quality]  (window {}s)", s.window_secs);
+    println!("\n[Connection Quality]  (window {})", s.window_label());
     let ms = |v: Option<f64>| v.map(|x| format!("{x:.1}")).unwrap_or_else(|| "—".into());
     for t in &s.targets {
         let st = t.stats(n);

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,6 +103,7 @@ async fn main() -> Result<()> {
         let mut s = state.lock().unwrap();
         s.speedtest_enabled = !cli.no_speedtest;
         s.samples_per_sec = 1000.0 / cfg.ping_interval_ms.max(1) as f64;
+        s.graph_marker = cfg.marker();
         s.speedtest_provider_names = provider_names;
         s.speedtest_provider_idx = sel;
         let (history, total) = store::load_recent(500);

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -945,12 +945,21 @@ fn latency_graph(f: &mut Frame, s: &AppState, n: usize, area: Rect) {
 fn quality_summary(f: &mut Frame, s: &AppState, n: usize, area: Rect) {
     let mut spans = vec![
         Span::styled(
-            format!("window {}s ", s.window_secs),
+            format!("window {} ", s.window_label()),
             Style::new().fg(Color::Gray),
         ),
         Span::styled("[w]", Style::new().fg(Color::Cyan)),
         Span::raw("  "),
     ];
+    // Say when the buffer, not the chosen window, is setting the reach. The
+    // figures are still honest — they just cover less than the label implies,
+    // and silently overstating them is worse than one extra clause.
+    if s.window_is_capped() {
+        spans.push(Span::styled(
+            format!("(capped at {} samples)  ", s.window_samples()),
+            Style::new().fg(Color::Yellow),
+        ));
+    }
     if let Some(t) = s.targets.get(s.graph_target) {
         let st = t.stats(n);
         spans.push(Span::styled(
@@ -1372,7 +1381,7 @@ fn help_overlay(f: &mut Frame, s: &AppState, area: Rect) {
         row("s", "run speed test"),
         row("p", "pause / resume refresh"),
         row("r", "re-probe network info"),
-        row("w", "stats window 30/60/300s"),
+        row("w", "stats window 1m/5m/15m"),
         row("l", "start / stop CSV recording"),
         row("?", "toggle this help"),
         row("q / Ctrl+C", "quit"),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -488,11 +488,12 @@ fn hop_monitor_view(f: &mut Frame, s: &AppState, n: usize, area: Rect) {
         (area, None)
     };
 
-    let b = block(&format!("Path · {}  ({status})", m.target), active);
+    let title = format!("Path · {}  ({status})", m.target);
+    let b = block(&title, active);
     let inner = b.inner(list_area);
-    f.render_widget(b, list_area);
 
     if inner.height == 0 || m.hops.is_empty() {
+        f.render_widget(b, list_area);
         f.render_widget(
             Paragraph::new(Span::styled(
                 "discovering path…",
@@ -514,16 +515,39 @@ fn hop_monitor_view(f: &mut Frame, s: &AppState, n: usize, area: Rect) {
 
     let header = Row::new(["ttl", "address", "loss", "last", "avg", "p95", "jitter"])
         .style(Style::new().fg(Color::Gray).bold());
-    // When the path doesn't fit, give up the last row to say so — silently
-    // truncating hides exactly the far end of the path you were looking for.
+    // Scroll so the selected hop stays on screen. Rows are not one-to-one with
+    // hops — a run of silent ones collapses to a single row — so the cursor is
+    // located by hop index rather than by counting rows.
     let rows_avail = inner.height.saturating_sub(1) as usize;
     let all_rows = hop_rows(&m.hops);
-    let overflow = all_rows.len().saturating_sub(rows_avail);
-    let visible: Vec<&HopRow> = if overflow > 0 && rows_avail > 0 {
-        all_rows.iter().take(rows_avail - 1).collect()
+    let cursor = all_rows
+        .iter()
+        .position(|r| matches!(r, HopRow::Hop(i, _) if *i == m.selected))
+        .unwrap_or(0);
+    let first = if rows_avail == 0 {
+        0
     } else {
-        all_rows.iter().take(rows_avail).collect()
+        cursor.saturating_sub(rows_avail - 1)
     };
+    let visible: Vec<&HopRow> = all_rows.iter().skip(first).take(rows_avail).collect();
+    let hidden_above = first;
+    let hidden_below = all_rows.len().saturating_sub(first + visible.len());
+
+    // Counts belong in the title, the way the target list does it. A footer row
+    // costs one of the rows it is complaining about, and it used to tell the
+    // reader to press [f] for full screen even when they were already in it.
+    let mut title = title;
+    if hidden_above > 0 || hidden_below > 0 {
+        title.push_str(" · ");
+        if hidden_above > 0 {
+            title.push_str(&format!("↑{hidden_above} "));
+        }
+        if hidden_below > 0 {
+            title.push_str(&format!("↓{hidden_below} "));
+        }
+        title.push_str("more");
+    }
+    f.render_widget(block(&title, active), list_area);
 
     let rows = visible.iter().map(|row| match row {
         // Left blank here and drawn afterwards across the whole row, since the
@@ -649,29 +673,13 @@ fn hop_monitor_view(f: &mut Frame, s: &AppState, n: usize, area: Rect) {
         }
     }
 
-    if overflow > 0 && rows_avail > 0 {
-        let y = inner.y + inner.height.saturating_sub(1);
-        f.render_widget(
-            Paragraph::new(Line::from(Span::styled(
-                format!("… +{overflow} more — press [f] for full screen"),
-                Style::new().fg(Color::Yellow),
-            ))),
-            Rect {
-                x: inner.x,
-                y,
-                width: inner.width,
-                height: 1,
-            },
-        );
-    }
-
     if let Some(chart_area) = chart_area {
-        hop_chart(f, m, n, chart_area);
+        hop_chart(f, m, n, chart_area, s.graph_marker);
     }
 }
 
 /// Latency history for the hop under the cursor, in its own panel.
-fn hop_chart(f: &mut Frame, m: &crate::app::HopMonitor, n: usize, area: Rect) {
+fn hop_chart(f: &mut Frame, m: &crate::app::HopMonitor, n: usize, area: Rect, marker: Marker) {
     let hop = m.hops.get(m.selected);
     let label = match hop {
         Some(h) => match h.addr {
@@ -726,17 +734,17 @@ fn hop_chart(f: &mut Frame, m: &crate::app::HopMonitor, n: usize, area: Rect) {
 
     let datasets = vec![
         Dataset::default()
-            .marker(Marker::Braille)
+            .marker(marker)
             .graph_type(GraphType::Line)
             .style(Style::new().fg(SERIES_COLOR))
             .data(&series),
         Dataset::default()
-            .marker(Marker::Braille)
+            .marker(marker)
             .graph_type(GraphType::Line)
             .style(Style::new().fg(P95_COLOR))
             .data(&p95_line),
         Dataset::default()
-            .marker(Marker::Braille)
+            .marker(marker)
             .graph_type(GraphType::Line)
             .style(Style::new().fg(JITTER_COLOR))
             .data(&jitter_line),
@@ -823,8 +831,17 @@ fn traceroute_view(f: &mut Frame, s: &AppState, area: Rect) {
             .map(hop_line)
             .collect();
         let remaining = tr.hops.len() - rows.saturating_sub(1);
+        // Unlike the path monitor this list has no cursor, so there is nothing
+        // to scroll with — in full screen the hint has nothing left to offer
+        // and saying "press [f] for full screen" to someone already there is
+        // just confusing.
+        let hint = if s.fullscreen {
+            ""
+        } else {
+            " — press [f] for full screen"
+        };
         v.push(Line::from(Span::styled(
-            format!("… +{remaining} more — press [f] for full screen"),
+            format!("… +{remaining} more{hint}"),
             Style::new().fg(Color::Yellow),
         )));
         v
@@ -885,17 +902,17 @@ fn latency_graph(f: &mut Frame, s: &AppState, n: usize, area: Rect) {
 
     let datasets = vec![
         Dataset::default()
-            .marker(Marker::Braille)
+            .marker(s.graph_marker)
             .graph_type(GraphType::Line)
             .style(Style::new().fg(SERIES_COLOR))
             .data(&series),
         Dataset::default()
-            .marker(Marker::Braille)
+            .marker(s.graph_marker)
             .graph_type(GraphType::Line)
             .style(Style::new().fg(P95_COLOR))
             .data(&p95_line),
         Dataset::default()
-            .marker(Marker::Braille)
+            .marker(s.graph_marker)
             .graph_type(GraphType::Line)
             .style(Style::new().fg(JITTER_COLOR))
             .data(&jitter_line),
@@ -1909,12 +1926,12 @@ fn link_util_graph(f: &mut Frame, s: &AppState, area: Rect) {
 
     let datasets = vec![
         Dataset::default()
-            .marker(Marker::Braille)
+            .marker(s.graph_marker)
             .graph_type(GraphType::Line)
             .style(Style::new().fg(Color::Green))
             .data(&dpts),
         Dataset::default()
-            .marker(Marker::Braille)
+            .marker(s.graph_marker)
             .graph_type(GraphType::Line)
             .style(Style::new().fg(Color::Magenta))
             .data(&upts),
@@ -1985,7 +2002,7 @@ fn signal_graph(f: &mut Frame, s: &AppState, area: Rect) {
 
     let mut datasets = vec![
         Dataset::default()
-            .marker(Marker::Braille)
+            .marker(s.graph_marker)
             .graph_type(GraphType::Line)
             .style(Style::new().fg(sig_color))
             .data(&sig_pts),
@@ -1993,7 +2010,7 @@ fn signal_graph(f: &mut Frame, s: &AppState, area: Rect) {
     if has_tx {
         datasets.push(
             Dataset::default()
-                .marker(Marker::Braille)
+                .marker(s.graph_marker)
                 .graph_type(GraphType::Line)
                 .style(Style::new().fg(Color::Cyan))
                 .data(&tx_pts),
@@ -2795,7 +2812,7 @@ mod tests {
     }
 
     #[test]
-    fn hop_list_says_when_it_has_more_than_fits() {
+    fn hop_list_scrolls_to_keep_the_selection_visible() {
         use crate::app::{HopMonitor, MonitoredHop, QualityView, TargetStat};
         use std::net::{IpAddr, Ipv4Addr};
 
@@ -2824,11 +2841,26 @@ mod tests {
             selected: 0,
         });
 
+        // Cursor at the top: the near end of the path is on screen, the far end
+        // is not, and the title says how much is below.
+        let out = draw(&s, 120, 24);
+        assert!(out.contains("10.0.0.1 "), "first hop visible");
+        assert!(!out.contains("10.0.0.25"), "last hop is past the fold");
+        assert!(out.contains("↓"), "title counts what is hidden below");
+        // The old footer told the reader to press [f] for full screen, which is
+        // unhelpful advice to someone already in full screen.
+        assert!(!out.contains("press [f] for full screen"));
+
+        // Moving the cursor to the far end scrolls the list to follow it.
+        // Without this the selection walks off the bottom and disappears.
+        s.hop_monitor.as_mut().unwrap().selected = 24;
         let out = draw(&s, 120, 24);
         assert!(
-            out.contains("press [f] for full screen"),
-            "a truncated path must say so"
+            out.contains("10.0.0.25"),
+            "the selected hop must be on screen"
         );
+        assert!(!out.contains("10.0.0.1 "), "the top has scrolled away");
+        assert!(out.contains("↑"), "title counts what is hidden above");
     }
 
     #[test]


### PR DESCRIPTION
Follow-ups from the first run on real Windows hardware. **Draft until the
Windows build is tested** — CI attaches binaries for both architectures.

## Path monitor would not scroll

It rendered rows from index 0 with no scroll offset, so moving the cursor past
the last visible row made the selection vanish instead of bringing the rest of
the path into view. The target list directly above it has always scrolled; the
monitor was simply never given the same treatment. Rows are not one-to-one with
hops — a run of silent ones collapses to a single row — so the cursor is
located by hop index.

The overflow footer said "press [f] for full screen" to people already in full
screen, and cost a row of the space it was complaining about. Counts now go in
the panel title as `↑n ↓n more`, matching the target list.

## Stats window

Stops were 30/60/300 cycling 60 → 300 → 30. 30 and 60 are 2x apart and give
near-identical averages, so one of three stops was wasted, and the cycle
widened twice then snapped narrower. p95 over 30 samples is also just "second
worst". Now 1m → 5m → 15m, ascending.

Separately `window_samples()` could ask for more than a target keeps. History
holds 1000 samples and `stats()` silently returns however many exist, so
`--ping-interval 250` made "window 300s" cover 250s with nothing saying so. Now
clamped, with the capacity a named constant rather than a literal two sites had
to agree on by luck, and the panel says `capped at n samples` when the buffer
rather than the window sets the reach.

## Chart glyphs

Charts plot with braille, which has no glyphs in the raster fonts a legacy
Windows console defaults to — every point renders as an empty box, and an
elevated window keeps its font setting separately, so the same machine can
render one way privileged and another way not. Rather than degrade everyone's
charts, `graph_marker` makes it a setting (`braille` default, `halfblock`,
`dot`, `block`, `bar`).

**Unconfirmed**: I have not verified the cause is the font rather than the
privilege level. Running elevated and unelevated in the same terminal settles
it.

## README

442 → 319 lines. The privilege material — two per-platform sections, the
rationale, and the unlock table — moves to `PRIVILEGES.md`, which gains a macOS
section that was only ever implied. README keeps a summary table and a link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)