### PR TITLE
v0.5.0: analysis engine, baselines, event timeline, HTTP probes, doctor mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,17 +51,19 @@ jobs:
       - name: Test
         run: cargo test
 
-      # Windows has no unprivileged per-process source, no ICMP guarantee and no
-      # Wi-Fi radio on a CI runner, so a good chunk of the Windows code can only
-      # be judged by running it on real hardware. Publishing the binary means
-      # that can happen without a Windows toolchain on the tester's machine.
-      # Release builds come from cargo-dist, not from here.
+      # A CI runner has no real Wi-Fi radio, no ICMP guarantee and (on Windows)
+      # no unprivileged per-process source, so much of the platform-specific
+      # code can only be judged by running it on real hardware. Publishing every
+      # platform's binary means that can happen without a Rust toolchain on the
+      # tester's machine. Release builds come from cargo-dist, not from here.
       - name: Upload binary for manual testing
-        if: startsWith(matrix.os, 'windows')
         uses: actions/upload-artifact@v4
         with:
           name: octomon-${{ matrix.os }}
-          path: target/release/octomon.exe
+          # Whichever of the two exists on this runner (.exe on Windows).
+          path: |
+            target/release/octomon
+            target/release/octomon.exe
           retention-days: 14
           if-no-files-found: error
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 **/*.rs.bk
 *.log
 .DS_Store
+# Local debug-binary copy for manual testing (`cp target/debug/octomon .`)
+/octomon

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1608,7 +1608,7 @@ dependencies = [
 
 [[package]]
 name = "octomon"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "octomon"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2024"
 description = "Btop-style terminal network monitor: latency, bandwidth, and Wi-Fi signal"
 repository = "https://github.com/securitypedant/octomon"

--- a/README.md
+++ b/README.md
@@ -12,9 +12,46 @@ network, the Wi-Fi, the ISP, or your own machine that's misbehaving.
 
 ## What it shows
 
-Four panels, all updating live. Everything below works unprivileged on macOS;
-Linux and Windows each hold one thing back, covered in
-[Privileges](#privileges).
+Four panels, all updating live — plus, as of v0.5.0, **an actual answer**. A
+**verdict line** at the bottom of the screen synthesizes everything octomon
+measures into one headline ("`▲ gateway unresponsive — likely (+1 more)`" or
+"`● connection healthy`"), and it never bluffs: press **`y`** ("why") for the
+**triage ladder** — every subsystem from your machine outward (machine → link →
+gateway → DNS → ISP path → internet → web → destinations) with its status *and
+the data behind it*, healthy rungs included. Simultaneous causes are all
+reported and ranked; a busy CPU is never allowed to hide a dead gateway, and a
+VPN is called out as a caveat on everything measured through it.
+
+Supporting that verdict:
+
+- **Per-network baselines** — octomon learns what *normal* looks like on each
+  network you use (gateway latency, DNS, signal, speed-test results), keyed by
+  a location fingerprint (SSID + gateway MAC), learned only from healthy
+  minutes so an incident never poisons the baseline it's judged against. Name
+  the current network with **`N`** ("Home", "Office") and the analysis reads
+  "gateway 41ms vs ~9ms normal at Home"; **`L`** lists every stored location
+  and its learned normals. Everything stays on your machine.
+- **Event timeline** (**`e`**) — the retroactive answer to "what happened
+  during that call ten minutes ago?": verdict findings raising and clearing
+  (with durations), network/SSID/DNS changes, VPN up/down, speed-test results,
+  all timestamped. Also drained into the CSV recording.
+- **HTTP reachability** — ICMP can be perfect while browsing is broken, so
+  octomon also probes a connectivity-check endpoint the way a browser would,
+  once per address family. Detects **captive portals** ("open the sign-in
+  page"), **web-blocked-while-ping-works** (proxy/firewall), and **broken IPv6
+  with working IPv4** — the classic "pages stall then load". Defaults to your
+  OS's own check endpoint (zero new parties learn you're online) and verifies
+  any failure against a second, independent provider before raising a finding.
+- **Doctor mode** — `octomon --doctor` observes headless for ~20 seconds
+  (tune with `--observe SECS`, add `--speedtest` for a full workup) and prints
+  the analysis, this network's learned normal, the raw measurements and recent
+  events; `--json` emits the same report for machines. **Redacted by default**
+  (SSID, IPs, MACs masked; ISP-side hop detail kept) so it's safe to paste
+  straight into a forum post or ISP ticket — `--full` prints everything. Exit
+  codes for scripting: `0` healthy, `1` problems found, `3` couldn't measure.
+
+The four panels — everything below works unprivileged on macOS; Linux and
+Windows each hold one thing back, covered in [Privileges](#privileges):
 
 - **Connection Quality** — ICMP latency to configurable targets with a full
   distribution (last / avg / p95 / max), **jitter**, **packet loss**, and a

--- a/src/app.rs
+++ b/src/app.rs
@@ -65,6 +65,46 @@ pub struct RttStats {
 /// position (ping tasks look up by id, making insertion/deletion safe).
 static NEXT_TARGET_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
+/// Whether a target serves HTTP, learned by probing. Absence of a web server
+/// is a fact, not a fault: only a target that has *demonstrated* a web service
+/// is ever judged on it.
+#[derive(Clone, Copy, PartialEq, Eq, Default, Debug)]
+pub enum WebStatus {
+    /// Not yet classified.
+    #[default]
+    Unknown,
+    /// Answered HTTP at least once — probed on a slow cadence from then on.
+    Web,
+    /// Connection actively refused: reachable, but nothing listens. Quiet "—".
+    NoService,
+    /// TCP times out while ICMP answers: something drops web traffic silently.
+    Filtered,
+}
+
+impl WebStatus {
+    pub fn label(self) -> &'static str {
+        match self {
+            WebStatus::Unknown => "unknown",
+            WebStatus::Web => "web",
+            WebStatus::NoService => "no-service",
+            WebStatus::Filtered => "filtered",
+        }
+    }
+}
+
+/// Per-target HTTP(S) reachability and time-to-first-byte. A latency
+/// instrument, not a security check: any HTTP status counts as "up".
+#[derive(Clone, Default)]
+pub struct WebProbe {
+    pub status: WebStatus,
+    /// TTFB of the most recent successful probe.
+    pub last_ttfb_ms: Option<f64>,
+    pub hist: History,
+    /// Consecutive failed probes while `status == Web` — the "it answered
+    /// before and stopped" signal the verdict watches.
+    pub fails: u32,
+}
+
 #[derive(Clone)]
 pub struct TargetStat {
     /// Stable identity, independent of index in the targets vec.
@@ -73,6 +113,12 @@ pub struct TargetStat {
     pub discovered: bool,
     pub label: String,
     pub addr: IpAddr,
+    /// The name this target was added as, when it was a name. Kept because a
+    /// CDN answers differently per network (re-resolved on change), and HTTPS
+    /// needs the hostname for SNI and certificates.
+    pub hostname: Option<String>,
+    /// HTTP(S) capability and timing, learned by the web prober.
+    pub web: WebProbe,
     pub last_rtt_ms: Option<f64>,
     /// RFC 3550 interarrival jitter (smoothed).
     pub jitter_ms: f64,
@@ -92,6 +138,8 @@ impl TargetStat {
             discovered: false,
             label,
             addr,
+            hostname: None,
+            web: WebProbe::default(),
             last_rtt_ms: None,
             jitter_ms: 0.0,
             min_ever_ms: None,
@@ -133,7 +181,9 @@ impl TargetStat {
         self.window.push_back(ok);
     }
 
-    /// Clear all accumulated stats (keeps identity, label, address).
+    /// Clear all accumulated stats (keeps identity, label, address, and the
+    /// learned web *capability* — whether a server exists doesn't reset, but
+    /// its timings do).
     pub fn reset(&mut self) {
         self.last_rtt_ms = None;
         self.jitter_ms = 0.0;
@@ -142,6 +192,16 @@ impl TargetStat {
         self.recv = 0;
         self.window.clear();
         self.history.data.clear();
+        self.web.hist.data.clear();
+        self.web.last_ttfb_ms = None;
+        self.web.fails = 0;
+    }
+
+    /// True for auto-discovered mid-path hops ("hop 3→1.1.1.1") — routers, not
+    /// destinations: the web prober skips them and the UI says so instead of
+    /// "checking…" forever.
+    pub fn is_path_hop(&self) -> bool {
+        self.discovered && self.label.starts_with("hop ")
     }
 
     /// Packet loss over the sliding window, as a percentage.
@@ -151,6 +211,24 @@ impl TargetStat {
         }
         let lost = self.window.iter().filter(|ok| !**ok).count();
         lost as f64 / self.window.len() as f64 * 100.0
+    }
+
+    /// Loss over only the most recent `n` outcomes. The full window takes
+    /// [`WINDOW`] seconds to reflect an outage, far too slow for *detection*;
+    /// display keeps using [`Self::loss_pct`].
+    pub fn recent_loss_pct(&self, n: usize) -> f64 {
+        let take = n.min(self.window.len());
+        if take == 0 {
+            return 0.0;
+        }
+        let lost = self
+            .window
+            .iter()
+            .rev()
+            .take(take)
+            .filter(|ok| !**ok)
+            .count();
+        lost as f64 / take as f64 * 100.0
     }
 
     /// Distribution over the most recent `n` successful samples.
@@ -501,6 +579,9 @@ impl LinkMedium {
 #[derive(Clone, Default)]
 pub struct NetInfo {
     pub iface: String,
+    /// OS interface index — the scope id a link-local (fe80::) address needs
+    /// to be routable, which is exactly how carrier hotspots hand out DNS.
+    pub iface_index: u32,
     pub ipv4: Vec<String>,
     pub ipv6: Vec<String>,
     pub mac: String,
@@ -598,6 +679,39 @@ impl DnsProbe {
         }
         (self.sent - self.ok) as f64 / self.sent as f64 * 100.0
     }
+}
+
+/// One address family's HTTP reachability probe result.
+#[derive(Clone, Default, PartialEq, Debug)]
+pub enum FamilyProbe {
+    #[default]
+    NotRun,
+    /// This family isn't configured here (e.g. no global IPv6 address) — a
+    /// v4-only LAN must never read as "v6 broken".
+    NotApplicable,
+    /// Expected answer received; round trip in ms.
+    Ok(f64),
+    /// Something intercepted the request — a portal sign-in page, usually.
+    /// Carries the redirect target when there was one.
+    Captive(Option<String>),
+    /// Connect/timeout/protocol failure, with a short reason.
+    Fail(String),
+}
+
+/// HTTP-layer reachability: the internet as a *browser* experiences it, which
+/// ICMP alone cannot see (captive portals, proxies, broken IPv6).
+#[derive(Clone, Default)]
+pub struct HttpState {
+    /// Provider name the primary probe used (e.g. "Apple").
+    pub provider: String,
+    pub v4: FamilyProbe,
+    pub v6: FamilyProbe,
+    /// Set when the second-opinion endpoint had to arbitrate.
+    pub note: Option<String>,
+    /// Round-trip history per family (successful probes only), for the web
+    /// graph in the Connection Quality panel.
+    pub v4_hist: History,
+    pub v6_hist: History,
 }
 
 /// Live Wi-Fi signal, sampled frequently (CoreWLAN on macOS) for graphing.
@@ -901,6 +1015,56 @@ mod tests {
     }
 
     #[test]
+    fn recent_loss_reacts_faster_than_the_display_window() {
+        let mut t = TargetStat::new("t".into(), IpAddr::V4(Ipv4Addr::LOCALHOST));
+        for _ in 0..80 {
+            t.record_reply(10.0);
+        }
+        for _ in 0..20 {
+            t.record_loss();
+        }
+        // The display window dilutes the outage; detection must not.
+        assert_eq!(t.loss_pct(), 20.0);
+        assert_eq!(t.recent_loss_pct(20), 100.0);
+        assert_eq!(t.recent_loss_pct(0), 0.0, "empty ask, no division by zero");
+    }
+
+    #[test]
+    fn the_timeline_is_capped_but_the_total_keeps_counting() {
+        let mut s = AppState::new(vec![]);
+        for i in 0..(EVENTS_CAP + 10) {
+            s.push_event(
+                crate::verdict::Severity::Info,
+                EventCategory::Network,
+                format!("event {i}"),
+            );
+        }
+        assert_eq!(s.events.len(), EVENTS_CAP);
+        assert_eq!(s.events_total, (EVENTS_CAP + 10) as u64);
+        // Oldest evicted, newest kept.
+        assert_eq!(s.events.front().unwrap().message, "event 10");
+        assert_eq!(
+            s.events.back().unwrap().message,
+            format!("event {}", EVENTS_CAP + 9)
+        );
+    }
+
+    #[test]
+    fn notice_event_is_both_transient_and_durable() {
+        let mut s = AppState::new(vec![]);
+        s.notice_event(
+            crate::verdict::Severity::Info,
+            EventCategory::Network,
+            "network changed → en7".into(),
+        );
+        assert_eq!(s.notice.as_deref(), Some("network changed → en7"));
+        assert_eq!(s.events.len(), 1);
+        // The notice dies with the next key press; the event survives it.
+        s.notice = None;
+        assert_eq!(s.events.back().unwrap().message, "network changed → en7");
+    }
+
+    #[test]
     fn loss_pct_counts_window() {
         let mut t = TargetStat::new("t".into(), IpAddr::V4(Ipv4Addr::LOCALHOST));
         t.record_reply(10.0);
@@ -926,7 +1090,80 @@ pub enum InputMode {
     Normal,
     /// Typing a new ICMP target (IP or DNS name).
     AddTarget,
+    /// Typing a name for the current network ("Home", "Office").
+    NameNetwork,
 }
+
+/// Which full-screen overlay is up, if any. One at a time; the order here is
+/// also the precedence at startup (setup problems before anything else).
+#[derive(Clone, Copy, PartialEq, Eq, Default)]
+pub enum Overlay {
+    #[default]
+    None,
+    /// Startup problems worth interrupting for (missing tools, no ICMP).
+    Startup,
+    Help,
+    /// The verdict's triage ladder: why the one-liner says what it says.
+    Triage,
+    /// The session timeline: what changed and when.
+    Events,
+    /// First-run welcome: what octomon answers and that it learns baselines.
+    Explainer,
+    /// Every stored network location and its learned baseline.
+    Locations,
+}
+
+/// Category of a timeline event, for the overlay and the CSV export.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum EventCategory {
+    /// An analysis finding raised or cleared — the flagship source: these give
+    /// "loss spike started / ended after 3m" for free.
+    Analysis,
+    Network,
+    Wifi,
+    Speedtest,
+    Path,
+    Logging,
+}
+
+impl EventCategory {
+    pub fn label(self) -> &'static str {
+        match self {
+            EventCategory::Analysis => "analysis",
+            EventCategory::Network => "network",
+            EventCategory::Wifi => "wifi",
+            EventCategory::Speedtest => "speedtest",
+            EventCategory::Path => "path",
+            EventCategory::Logging => "logging",
+        }
+    }
+}
+
+/// One entry in the session timeline. People open a diagnostic tool *after*
+/// the glitch; averages hide a ten-second dropout, a transition log answers it.
+#[derive(Clone)]
+pub struct EventItem {
+    /// Unix timestamp (seconds), like [`crate::store::SpeedRecord::at`].
+    pub at: i64,
+    pub severity: crate::verdict::Severity,
+    pub category: EventCategory,
+    pub message: String,
+}
+
+impl EventItem {
+    /// Local wall-clock time for display, e.g. "21:14:03".
+    pub fn when(&self) -> String {
+        use chrono::{Local, TimeZone};
+        Local
+            .timestamp_opt(self.at, 0)
+            .single()
+            .map(|dt| dt.format("%H:%M:%S").to_string())
+            .unwrap_or_else(|| "—".to_string())
+    }
+}
+
+/// Bounded timeline length; older events fall off the front.
+pub const EVENTS_CAP: usize = 500;
 
 /// An in-progress session recording.
 #[derive(Clone)]
@@ -945,6 +1182,8 @@ pub struct AppState {
     pub netinfo: NetInfo,
     /// Per-resolver DNS responsiveness, in the order the interface reports them.
     pub dns: Vec<DnsProbe>,
+    /// HTTP-layer reachability (captive portal / broken-v6 detection).
+    pub http: HttpState,
     pub signal: SignalState,
     pub vitals: Vitals,
     /// Error/drop counters for the default interface.
@@ -1009,13 +1248,32 @@ pub struct AppState {
     pub notice: Option<String>,
     /// Auto-refresh paused: the periodic redraw is suppressed.
     pub paused: bool,
-    /// Help overlay visible.
-    pub show_help: bool,
+    /// Which full-screen overlay is up, if any.
+    pub overlay: Overlay,
+    /// Synthesized diagnosis: the footer one-liner and the triage ladder.
+    pub verdict: crate::verdict::VerdictState,
+    /// This network's learned baseline (present once the network is
+    /// fingerprinted; freshly created when the network is new).
+    pub baseline: Option<crate::baseline::Baseline>,
+    /// Fingerprint key of the current network, for persisting the baseline.
+    pub baseline_key: Option<String>,
+    /// Show the first-run explainer once the startup notice is dismissed.
+    pub explainer_pending: bool,
+    /// Stored locations for the [L] overlay: (fingerprint key, baseline),
+    /// loaded from disk when the overlay opens. `None` = still loading.
+    pub locations: Option<Vec<(String, crate::baseline::Baseline)>>,
+    /// Scroll offset into the locations list.
+    pub locations_sel: usize,
+    /// Session timeline of state transitions (oldest → newest), capped.
+    pub events: VecDeque<EventItem>,
+    /// Events ever pushed — exceeds `events.len()` once the cap evicts, and
+    /// serves as the CSV logger's high-water mark.
+    pub events_total: u64,
+    /// How far back the events overlay is scrolled (0 = newest).
+    pub events_scroll: usize,
     /// Set when the ICMP socket could not be opened, with guidance on the fix.
     /// Everything latency-related is dead without it.
     pub icmp_error: Option<String>,
-    /// Startup problems worth interrupting for, shown until dismissed.
-    pub show_startup_notice: bool,
     /// What is degraded by running unprivileged, when anything is.
     pub privilege_notice: Option<String>,
     /// External tools absent from this machine: (name, what it provides, how to
@@ -1038,6 +1296,7 @@ impl AppState {
             speedtest: SpeedTest::default(),
             netinfo: NetInfo::default(),
             dns: Vec::new(),
+            http: HttpState::default(),
             signal: SignalState::default(),
             vitals: Vitals::default(),
             link_errors: LinkErrors::default(),
@@ -1070,9 +1329,17 @@ impl AppState {
             input_buffer: String::new(),
             notice: None,
             paused: false,
-            show_help: false,
+            overlay: Overlay::None,
+            verdict: crate::verdict::VerdictState::default(),
+            baseline: None,
+            baseline_key: None,
+            explainer_pending: false,
+            locations: None,
+            locations_sel: 0,
+            events: VecDeque::new(),
+            events_total: 0,
+            events_scroll: 0,
             icmp_error: None,
-            show_startup_notice: false,
             privilege_notice: None,
             missing_tools: Vec::new(),
             logging_requested: false,
@@ -1080,6 +1347,55 @@ impl AppState {
             should_quit: false,
             started: Instant::now(),
         }
+    }
+
+    /// Clear every latency statistic: targets, monitored hops, the one-shot
+    /// traceroute. Used by Shift+R, and automatically when the link comes back
+    /// or the machine moves networks — stats from before either event describe
+    /// a path that no longer exists, and stale loss would stay red for minutes.
+    pub fn reset_quality_stats(&mut self) {
+        for t in &mut self.targets {
+            t.reset();
+        }
+        if let Some(m) = self.hop_monitor.as_mut() {
+            for h in &mut m.hops {
+                if let Some(stat) = h.stat.as_mut() {
+                    stat.reset();
+                }
+            }
+        }
+        self.traceroute = None;
+    }
+
+    /// Append to the session timeline, evicting the oldest past the cap.
+    pub fn push_event(
+        &mut self,
+        severity: crate::verdict::Severity,
+        category: EventCategory,
+        message: String,
+    ) {
+        if self.events.len() == EVENTS_CAP {
+            self.events.pop_front();
+        }
+        self.events.push_back(EventItem {
+            at: chrono::Utc::now().timestamp(),
+            severity,
+            category,
+            message,
+        });
+        self.events_total += 1;
+    }
+
+    /// Show a transient footer notice *and* keep it in the timeline — the
+    /// durable sibling of `notice`, which any key press clears.
+    pub fn notice_event(
+        &mut self,
+        severity: crate::verdict::Severity,
+        category: EventCategory,
+        message: String,
+    ) {
+        self.notice = Some(message.clone());
+        self.push_event(severity, category, message);
     }
 
     /// Whether the focused panel currently offers a second cursor pane, so 'n'

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -143,7 +143,10 @@ pub fn fingerprint(n: &NetInfo) -> Option<(String, String)> {
 
     let (raw, label) = if n.medium == LinkMedium::WiFi && !ssid.is_empty() {
         (
-            format!("{ssid}|{}|wifi", if mac_known { &n.gateway_mac } else { "" }),
+            format!(
+                "{ssid}|{}|wifi",
+                if mac_known { &n.gateway_mac } else { "" }
+            ),
             ssid.to_string(),
         )
     } else if mac_known {

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -1,0 +1,334 @@
+//! Per-network baselines: what *normal* looks like on this network, learned
+//! only while the verdict is fully healthy and persisted per location.
+//!
+//! "45 ms to the gateway" is meaningless in isolation — the question is "is
+//! this normal *for me, here*?". Each network the machine joins is
+//! fingerprinted (SSID + gateway MAC on Wi-Fi, gateway MAC on a cable), so a
+//! laptop that moves between home, office and café keeps a separate notion of
+//! normal for each, and the verdict can say "gateway 41ms vs ~9ms normal at
+//! Home". The healthy-only gate is the anti-poisoning rule: an incident never
+//! contaminates the baseline it will be judged against.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::app::{AppState, LinkMedium, NetInfo};
+use crate::verdict::thresholds as th;
+
+/// EWMA weight for folding a new observation in: slow enough that one odd
+/// minute barely moves it, fast enough to converge within an evening.
+const ALPHA: f64 = 0.2;
+
+/// Baseline comparisons stay quiet until this many healthy folds.
+pub const MIN_SAMPLES: u32 = 5;
+
+/// Learned normals for one network. All values are EWMAs of windowed
+/// aggregates, folded in once per healthy minute.
+#[derive(Clone, Default, Serialize, Deserialize)]
+pub struct Baseline {
+    /// Auto label: the SSID, or the gateway address on a cable.
+    pub label: String,
+    /// User-given name ("Home", "Office"), set with [N].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// Healthy folds so far — confidence in the baseline itself.
+    pub samples: u32,
+    pub gateway_ms: Option<f64>,
+    pub gateway_p95_ms: Option<f64>,
+    pub anchor_ms: Option<f64>,
+    pub dns_ms: Option<f64>,
+    pub rssi_dbm: Option<f64>,
+    pub down_mbps: Option<f64>,
+    pub up_mbps: Option<f64>,
+}
+
+impl Baseline {
+    /// Whether comparisons against this baseline are worth voicing.
+    pub fn established(&self) -> bool {
+        self.samples >= MIN_SAMPLES
+    }
+
+    /// The name to use in verdicts: the user's, else the auto label.
+    pub fn display_name(&self) -> &str {
+        self.name.as_deref().unwrap_or(&self.label)
+    }
+}
+
+/// One minute's healthy aggregates, computed under the state lock.
+#[derive(Clone, Copy, Default)]
+pub struct Sample {
+    pub gateway_ms: Option<f64>,
+    pub gateway_p95_ms: Option<f64>,
+    pub anchor_ms: Option<f64>,
+    pub dns_ms: Option<f64>,
+    pub rssi_dbm: Option<f64>,
+}
+
+impl Sample {
+    /// Read the current windowed aggregates out of shared state.
+    pub fn take(s: &AppState) -> Sample {
+        let n = 60;
+        let gw = s
+            .targets
+            .iter()
+            .find(|t| t.discovered && t.addr.to_string() == s.netinfo.gateway_ip);
+        let (gateway_ms, gateway_p95_ms) = gw
+            .map(|g| {
+                let st = g.stats(n);
+                (st.mean, st.p95)
+            })
+            .unwrap_or_default();
+        // Best (lowest-mean) anchor: "how far away is the internet at its best".
+        let anchor_ms = s
+            .targets
+            .iter()
+            .filter(|t| !t.discovered)
+            .filter_map(|t| t.stats(n).mean)
+            .min_by(f64::total_cmp);
+        let dns: Vec<f64> = s.dns.iter().filter_map(|p| p.mean_ms()).collect();
+        let dns_ms = (!dns.is_empty()).then(|| dns.iter().sum::<f64>() / dns.len() as f64);
+        let rssi_dbm = s.signal.present.then_some(s.signal.rssi_dbm as f64);
+        Sample {
+            gateway_ms,
+            gateway_p95_ms,
+            anchor_ms,
+            dns_ms,
+            rssi_dbm,
+        }
+    }
+}
+
+fn ewma(prev: Option<f64>, new: Option<f64>) -> Option<f64> {
+    match (prev, new) {
+        (Some(p), Some(n)) => Some(p + ALPHA * (n - p)),
+        (None, n) => n,
+        (p, None) => p,
+    }
+}
+
+impl Baseline {
+    /// Fold one healthy minute in.
+    pub fn fold(&mut self, sample: Sample) {
+        self.gateway_ms = ewma(self.gateway_ms, sample.gateway_ms);
+        self.gateway_p95_ms = ewma(self.gateway_p95_ms, sample.gateway_p95_ms);
+        self.anchor_ms = ewma(self.anchor_ms, sample.anchor_ms);
+        self.dns_ms = ewma(self.dns_ms, sample.dns_ms);
+        self.rssi_dbm = ewma(self.rssi_dbm, sample.rssi_dbm);
+        self.samples += 1;
+    }
+}
+
+/// Fingerprint "which network is this" → (stable key, human label).
+///
+/// Wi-Fi keys on SSID + gateway MAC: the pair survives DHCP renewals and mesh
+/// roaming, distinguishes two networks sharing a generic SSID, and needs no
+/// Location permission (when macOS redacts the SSID, the gateway MAC still
+/// identifies the network). A cable keys on the gateway MAC alone. No gateway
+/// at all → no baseline, rather than a garbage key.
+pub fn fingerprint(n: &NetInfo) -> Option<(String, String)> {
+    let mac_known = !n.gateway_mac.is_empty() && n.gateway_mac != "-";
+    let ip_known = !n.gateway_ip.is_empty() && n.gateway_ip != "-";
+    // macOS returns the literal "<redacted>" without Location Services; that is
+    // not an identity.
+    let ssid = n
+        .wifi
+        .as_ref()
+        .map(|w| w.ssid.as_str())
+        .filter(|s| !s.is_empty() && !s.contains("redacted"))
+        .unwrap_or("");
+    if !mac_known && !ip_known && ssid.is_empty() {
+        return None;
+    }
+
+    let (raw, label) = if n.medium == LinkMedium::WiFi && !ssid.is_empty() {
+        (
+            format!("{ssid}|{}|wifi", if mac_known { &n.gateway_mac } else { "" }),
+            ssid.to_string(),
+        )
+    } else if mac_known {
+        (
+            format!("{}|{}", n.gateway_mac, n.medium as u8),
+            n.gateway_ip.clone(),
+        )
+    } else if ip_known {
+        (
+            format!("{}|{}|{}", n.gateway_ip, n.iface, n.medium as u8),
+            n.gateway_ip.clone(),
+        )
+    } else {
+        // v6-only carrier hotspots can expose no routable gateway at all;
+        // the SSID is then the only identity available — and "iPhone" is
+        // exactly the location a hotspot baseline should be keyed to.
+        (format!("{ssid}|nogw|{}", n.medium as u8), ssid.to_string())
+    };
+
+    // Hash the identity so the on-disk keys don't spell out SSIDs; the label
+    // field stays human-readable for display.
+    use std::hash::{DefaultHasher, Hash, Hasher};
+    let mut h = DefaultHasher::new();
+    raw.hash(&mut h);
+    Some((format!("{:016x}", h.finish()), label))
+}
+
+/// All known baselines, keyed by fingerprint hash.
+pub type Store = HashMap<String, Baseline>;
+
+fn path() -> Option<std::path::PathBuf> {
+    crate::store::data_dir().map(|d| d.join("baselines.json"))
+}
+
+/// Best-effort load; a corrupt or missing file is an empty map, never a crash.
+pub fn load() -> Store {
+    let Some(p) = path() else {
+        return Store::new();
+    };
+    std::fs::read_to_string(p)
+        .ok()
+        .and_then(|text| serde_json::from_str(&text).ok())
+        .unwrap_or_default()
+}
+
+/// Best-effort whole-file rewrite — a handful of networks × ~200 bytes.
+pub fn save(store: &Store) {
+    let Some(p) = path() else { return };
+    if let Some(dir) = p.parent() {
+        let _ = std::fs::create_dir_all(dir);
+    }
+    if let Ok(json) = serde_json::to_string_pretty(store) {
+        let _ = std::fs::write(p, json);
+    }
+}
+
+/// Load one network's baseline (blocking file read — call off the lock).
+pub fn load_one(key: &str) -> Option<Baseline> {
+    load().get(key).cloned()
+}
+
+/// Merge one network's baseline back in and persist (blocking — off the lock).
+pub fn save_one(key: &str, b: &Baseline) {
+    let mut all = load();
+    all.insert(key.to_string(), b.clone());
+    save(&all);
+}
+
+/// Set the user's name for a network, keeping any learned stats.
+pub fn name_network(key: &str, label: &str, name: &str) {
+    let mut all = load();
+    let entry = all.entry(key.to_string()).or_insert_with(|| Baseline {
+        label: label.to_string(),
+        ..Default::default()
+    });
+    entry.name = if name.trim().is_empty() {
+        None
+    } else {
+        Some(name.trim().to_string())
+    };
+    save(&all);
+}
+
+/// "current is way above normal": the abnormality test used for confidence
+/// bumps. Both a ratio and an absolute margin, so a 2 ms → 7 ms gateway
+/// (noise) doesn't count but 9 ms → 41 ms does.
+pub fn well_above(current: f64, normal: f64) -> bool {
+    current > (normal * th::RTT_INFLATED_FACTOR).max(normal + 20.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::WifiInfo;
+
+    fn wifi_net(ssid: &str, gw_mac: &str) -> NetInfo {
+        NetInfo {
+            iface: "en0".into(),
+            gateway_ip: "192.168.1.1".into(),
+            gateway_mac: gw_mac.into(),
+            medium: LinkMedium::WiFi,
+            wifi: Some(WifiInfo {
+                ssid: ssid.into(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn fingerprint_distinguishes_locations_and_survives_dhcp() {
+        let home = fingerprint(&wifi_net("HomeNet", "aa:bb:cc:dd:ee:ff")).unwrap();
+        let cafe = fingerprint(&wifi_net("HomeNet", "11:22:33:44:55:66")).unwrap();
+        assert_ne!(home.0, cafe.0, "same generic SSID, different routers");
+        assert_eq!(home.1, "HomeNet", "label is the SSID");
+
+        // A DHCP renewal changes the local IP but neither key ingredient.
+        let mut renewed = wifi_net("HomeNet", "aa:bb:cc:dd:ee:ff");
+        renewed.ipv4 = vec!["192.168.1.200/24".into()];
+        assert_eq!(home.0, fingerprint(&renewed).unwrap().0);
+    }
+
+    #[test]
+    fn redacted_ssid_falls_back_to_the_gateway_mac() {
+        let n = wifi_net("<redacted>", "aa:bb:cc:dd:ee:ff");
+        let (key, label) = fingerprint(&n).unwrap();
+        // Still identifiable, labelled by gateway instead of the hidden SSID.
+        assert_eq!(label, "192.168.1.1");
+        // ...and identical to the same network seen without wifi details yet.
+        let mut no_wifi = n.clone();
+        no_wifi.wifi = None;
+        no_wifi.medium = LinkMedium::WiFi;
+        // Different path (no ssid): falls to mac|medium — consistent with above.
+        assert_eq!(key, fingerprint(&no_wifi).unwrap().0);
+    }
+
+    #[test]
+    fn wired_and_wifi_on_the_same_router_are_different_networks() {
+        let wifi = fingerprint(&wifi_net("HomeNet", "aa:bb:cc:dd:ee:ff")).unwrap();
+        let mut wired = wifi_net("", "aa:bb:cc:dd:ee:ff");
+        wired.wifi = None;
+        wired.medium = LinkMedium::Ethernet;
+        let wired = fingerprint(&wired).unwrap();
+        assert_ne!(wifi.0, wired.0, "different medium, different baseline");
+    }
+
+    /// A v6-only carrier hotspot exposes no routable gateway; the SSID alone
+    /// still identifies the location ("iPhone" IS the place).
+    #[test]
+    fn gatewayless_wifi_falls_back_to_the_ssid_alone() {
+        let mut n = wifi_net("iPhone", "-");
+        n.gateway_ip = "-".into();
+        let (_, label) = fingerprint(&n).expect("ssid-only fingerprint");
+        assert_eq!(label, "iPhone");
+
+        // With no SSID either there is genuinely nothing to key on.
+        let mut bare = wifi_net("", "-");
+        bare.gateway_ip = "-".into();
+        assert!(fingerprint(&bare).is_none());
+    }
+
+    #[test]
+    fn ewma_converges_and_missing_readings_do_not_erase() {
+        let mut b = Baseline::default();
+        for _ in 0..40 {
+            b.fold(Sample {
+                gateway_ms: Some(10.0),
+                ..Default::default()
+            });
+        }
+        let g = b.gateway_ms.unwrap();
+        assert!((g - 10.0).abs() < 0.1, "converged to ~10, got {g}");
+        assert_eq!(b.samples, 40);
+        assert!(b.established());
+
+        // A fold with no gateway reading must not wipe what was learned.
+        b.fold(Sample::default());
+        assert!((b.gateway_ms.unwrap() - 10.0).abs() < 0.1);
+    }
+
+    #[test]
+    fn abnormality_needs_both_ratio_and_margin() {
+        assert!(!well_above(7.0, 2.0), "3.5x of nothing is still nothing");
+        assert!(!well_above(25.0, 9.0), "under the ratio");
+        assert!(well_above(41.0, 9.0));
+        assert!(well_above(400.0, 100.0));
+    }
+}

--- a/src/collectors/discovery.rs
+++ b/src/collectors/discovery.rs
@@ -5,7 +5,6 @@
 use std::net::IpAddr;
 use std::sync::{Arc, Mutex};
 
-use surge_ping::Client;
 use tokio::process::Command;
 
 use crate::app::{AppState, TargetStat};
@@ -15,7 +14,7 @@ use crate::platform::traceroute as tr;
 
 const MAX_HOPS: usize = 4; // gateway (1) + next three
 
-pub async fn run(state: Arc<Mutex<AppState>>, client: Arc<Client>, cfg: Config) {
+pub async fn run(state: Arc<Mutex<AppState>>, clients: ping::Clients, cfg: Config) {
     // Configurable: the useful probe target depends on the network. Empty
     // disables discovery entirely, like `public_ip_url`.
     let probe = cfg.discovery_probe.trim().to_string();
@@ -62,7 +61,7 @@ pub async fn run(state: Arc<Mutex<AppState>>, client: Arc<Client>, cfg: Config) 
             }
         };
         if added {
-            ping::spawn_for(state.clone(), client.clone(), cfg.clone(), id, addr);
+            ping::spawn_for(state.clone(), clients.clone(), cfg.clone(), id, addr);
         }
     }
 }
@@ -70,7 +69,7 @@ pub async fn run(state: Arc<Mutex<AppState>>, client: Arc<Client>, cfg: Config) 
 /// Re-run discovery after the machine moved to a different network: the old
 /// gateway and hops belong to a network that is no longer reachable, so they are
 /// dropped before the path is walked again. Hand-added targets are left alone.
-pub async fn refresh(state: Arc<Mutex<AppState>>, client: Arc<Client>, cfg: Config) {
+pub async fn refresh(state: Arc<Mutex<AppState>>, clients: ping::Clients, cfg: Config) {
     {
         let mut s = state.lock().unwrap();
         s.targets.retain(|t| !t.discovered);
@@ -79,15 +78,15 @@ pub async fn refresh(state: Arc<Mutex<AppState>>, client: Arc<Client>, cfg: Conf
         s.selected = s.selected.min(last);
         s.graph_target = s.graph_target.min(last);
     }
-    run(state.clone(), client.clone(), cfg.clone()).await;
-    public_ip(state, client, cfg).await;
+    run(state.clone(), clients.clone(), cfg.clone()).await;
+    public_ip(state, clients, cfg).await;
 }
 
 /// Watch for the network changing under us and rebuild everything derived from
 /// it: the discovered targets, and the path monitor if one is running.
 pub async fn watch(
     state: Arc<Mutex<AppState>>,
-    client: Arc<Client>,
+    clients: ping::Clients,
     cfg: Config,
     changed: Arc<tokio::sync::Notify>,
 ) {
@@ -111,14 +110,14 @@ pub async fn watch(
         }
         seen = seq;
 
-        refresh(state.clone(), client.clone(), cfg.clone()).await;
+        refresh(state.clone(), clients.clone(), cfg.clone()).await;
 
         // A path monitored on the old network says nothing about the new one.
         if let Some((dest, label)) = monitoring {
             let label = label.split(" (").next().unwrap_or(&label).to_string();
             crate::collectors::hopmon::start(
                 state.clone(),
-                client.clone(),
+                clients.clone(),
                 cfg.clone(),
                 dest,
                 label,
@@ -130,7 +129,7 @@ pub async fn watch(
 /// Discover the machine's public IP from `cfg.public_ip_url` (a plain-text IP
 /// endpoint) and add it as a target. No-op if the URL is empty or the response
 /// isn't a valid IP.
-pub async fn public_ip(state: Arc<Mutex<AppState>>, client: Arc<Client>, cfg: Config) {
+pub async fn public_ip(state: Arc<Mutex<AppState>>, clients: ping::Clients, cfg: Config) {
     if cfg.public_ip_url.trim().is_empty() {
         return;
     }
@@ -161,7 +160,7 @@ pub async fn public_ip(state: Arc<Mutex<AppState>>, client: Arc<Client>, cfg: Co
         }
     };
     if added {
-        ping::spawn_for(state, client, cfg, id, addr);
+        ping::spawn_for(state, clients, cfg, id, addr);
     }
 }
 

--- a/src/collectors/dns.rs
+++ b/src/collectors/dns.rs
@@ -27,13 +27,16 @@ pub async fn run(state: Arc<Mutex<AppState>>, cfg: Config) {
 
         // Follow whatever resolvers the current interface reports; these change
         // when the network does, or when a VPN installs its own proxy.
-        let servers: Vec<IpAddr> = {
+        let (servers, scope): (Vec<IpAddr>, u32) = {
             let s = state.lock().unwrap();
-            s.netinfo
-                .dns
-                .iter()
-                .filter_map(|d| d.parse::<IpAddr>().ok())
-                .collect()
+            (
+                s.netinfo
+                    .dns
+                    .iter()
+                    .filter_map(|d| d.parse::<IpAddr>().ok())
+                    .collect(),
+                s.netinfo.iface_index,
+            )
         };
         if servers.is_empty() {
             state.lock().unwrap().dns.clear();
@@ -43,7 +46,7 @@ pub async fn run(state: Arc<Mutex<AppState>>, cfg: Config) {
         for server in servers {
             id = id.wrapping_add(1);
             let started = Instant::now();
-            let outcome = query(server, &name, id, cfg.dns_timeout()).await;
+            let outcome = query(server, scope, &name, id, cfg.dns_timeout()).await;
             let elapsed = started.elapsed().as_secs_f64() * 1000.0;
 
             let mut s = state.lock().unwrap();
@@ -90,16 +93,29 @@ pub async fn run(state: Arc<Mutex<AppState>>, cfg: Config) {
     }
 }
 
-/// Send one A query and time the answer.
-async fn query(server: IpAddr, name: &str, id: u16, timeout: Duration) -> Result<u16, String> {
+/// Send one A query and time the answer. `scope` is the interface index a
+/// link-local v6 resolver needs — carrier hotspots hand out `fe80::…` as the
+/// DNS server, and without the scope every packet fails with "no route to
+/// host" even though resolution works fine for the system.
+async fn query(
+    server: IpAddr,
+    scope: u32,
+    name: &str,
+    id: u16,
+    timeout: Duration,
+) -> Result<u16, String> {
     let bind: SocketAddr = match server {
         IpAddr::V4(_) => (Ipv4Addr::UNSPECIFIED, 0).into(),
         IpAddr::V6(_) => (Ipv6Addr::UNSPECIFIED, 0).into(),
     };
     let sock = UdpSocket::bind(bind).await.map_err(|e| short(&e))?;
-    sock.connect(SocketAddr::new(server, 53))
-        .await
-        .map_err(|e| short(&e))?;
+    let dest: SocketAddr = match server {
+        IpAddr::V6(v6) if (v6.segments()[0] & 0xffc0) == 0xfe80 => {
+            std::net::SocketAddrV6::new(v6, 53, 0, scope).into()
+        }
+        other => SocketAddr::new(other, 53),
+    };
+    sock.connect(dest).await.map_err(|e| short(&e))?;
 
     let packet = build_query(id, name);
     sock.send(&packet).await.map_err(|e| short(&e))?;
@@ -228,7 +244,7 @@ mod tests {
         for server in ["1.1.1.1", "8.8.8.8"] {
             let ip: IpAddr = server.parse().unwrap();
             let started = Instant::now();
-            let r = query(ip, "example.com", 1, Duration::from_secs(2)).await;
+            let r = query(ip, 0, "example.com", 1, Duration::from_secs(2)).await;
             println!(
                 "{server}: {:?} in {:.1}ms",
                 r,

--- a/src/collectors/hopmon.rs
+++ b/src/collectors/hopmon.rs
@@ -13,10 +13,11 @@ use std::process::Stdio;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use surge_ping::{Client, PingIdentifier, PingSequence};
+use surge_ping::{PingIdentifier, PingSequence};
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 
+use super::ping;
 use crate::app::{AppState, HopMonitor, MonitoredHop, TargetStat};
 use crate::config::Config;
 use crate::platform::traceroute as tr;
@@ -36,7 +37,7 @@ fn ping_id(generation: u64, ttl: u8) -> u16 {
 /// Begin (or restart) continuous monitoring of the path to `dest`.
 pub fn start(
     state: Arc<Mutex<AppState>>,
-    client: Arc<Client>,
+    clients: ping::Clients,
     cfg: Config,
     dest: IpAddr,
     label: String,
@@ -57,7 +58,7 @@ pub fn start(
 
     tokio::spawn(async move {
         loop {
-            discover(&state, &client, &cfg, dest, generation).await;
+            discover(&state, &clients, &cfg, dest, generation).await;
             if superseded(&state, generation) {
                 return;
             }
@@ -92,7 +93,7 @@ fn superseded(state: &Arc<Mutex<AppState>>, generation: u64) -> bool {
 /// a probe for each newly resolved hop. Streams so hops appear as they arrive.
 async fn discover(
     state: &Arc<Mutex<AppState>>,
-    client: &Arc<Client>,
+    clients: &ping::Clients,
     cfg: &Config,
     dest: IpAddr,
     generation: u64,
@@ -113,7 +114,11 @@ async fn discover(
         {
             m.discovering = false;
         }
-        s.notice = Some(format!("{} unavailable", tr::PROGRAM));
+        s.notice_event(
+            crate::verdict::Severity::Info,
+            crate::app::EventCategory::Path,
+            format!("{} unavailable", tr::PROGRAM),
+        );
         return;
     };
 
@@ -140,7 +145,7 @@ async fn discover(
             if let Some(addr) = spawn {
                 spawn_probe(
                     state.clone(),
-                    client.clone(),
+                    clients.clone(),
                     cfg.clone(),
                     generation,
                     hop.ttl,
@@ -190,12 +195,17 @@ fn merge_hop(m: &mut HopMonitor, ttl: u8, addr: Option<IpAddr>) -> Option<IpAddr
 /// Keep one hop measured until its monitor run ends or its address changes.
 fn spawn_probe(
     state: Arc<Mutex<AppState>>,
-    client: Arc<Client>,
+    clients: ping::Clients,
     cfg: Config,
     generation: u64,
     ttl: u8,
     addr: IpAddr,
 ) {
+    // Hops on a v6 path need the v6 client and vice versa; a hop whose family
+    // has no client just stays unmeasured rather than reading as loss.
+    let Some(client) = clients.for_addr(addr) else {
+        return;
+    };
     tokio::spawn(async move {
         let mut pinger = client
             .pinger(addr, PingIdentifier(ping_id(generation, ttl)))
@@ -301,11 +311,12 @@ mod tests {
     #[ignore = "requires network access"]
     async fn live_path_monitor() {
         let state = Arc::new(Mutex::new(AppState::new(vec![])));
-        let client = Arc::new(Client::new(&surge_ping::Config::default()).unwrap());
+        let (clients, err) = ping::Clients::open();
+        assert!(err.is_none(), "ICMP unavailable: {err:?}");
         let dest: IpAddr = "1.1.1.1".parse().unwrap();
         start(
             state.clone(),
-            client,
+            clients,
             Config::default(),
             dest,
             "Cloudflare".into(),

--- a/src/collectors/http.rs
+++ b/src/collectors/http.rs
@@ -130,11 +130,7 @@ pub fn classify(
 /// not just the automatic link-local (fe80::) or a ULA-only setup.
 pub fn has_global_v6(addrs: &[String]) -> bool {
     addrs.iter().any(|a| {
-        let Some(ip) = a
-            .split('/')
-            .next()
-            .and_then(|s| s.parse::<Ipv6Addr>().ok())
-        else {
+        let Some(ip) = a.split('/').next().and_then(|s| s.parse::<Ipv6Addr>().ok()) else {
             return false;
         };
         let seg = ip.segments();

--- a/src/collectors/http.rs
+++ b/src/collectors/http.rs
@@ -1,0 +1,360 @@
+//! HTTP-layer reachability: probe a well-known connectivity-check endpoint the
+//! way a browser would, once per address family.
+//!
+//! ICMP can be perfect while browsing is broken — captive portals, proxy
+//! failures and half-broken IPv6 all live above the layer ping tests. Every OS
+//! runs an endpoint for exactly this purpose; the default is *this* OS's own
+//! (the machine already polls it constantly, so octomon adds zero new parties
+//! learning it is online). Plain HTTP on purpose: portals must be able to
+//! intercept the request, that's the test.
+//!
+//! A failing/captive answer is verified against a second, independent provider
+//! before it stands — one endpoint having a bad day must not read as "your
+//! network is broken" (same philosophy as multi-anchor ping consensus).
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+use futures_util::StreamExt;
+use tokio::sync::Notify;
+
+use crate::app::{AppState, FamilyProbe};
+use crate::config::Config;
+
+/// What the endpoint answers when the internet is actually reachable.
+#[derive(Clone, Copy)]
+pub enum Expect {
+    /// An empty 204 (or empty 200).
+    Empty,
+    /// A 200 whose body contains this needle.
+    Body(&'static str),
+}
+
+pub struct Provider {
+    pub name: &'static str,
+    pub url: &'static str,
+    pub expects: Expect,
+}
+
+/// The well-known connectivity-check endpoints, both flavours.
+pub static PROVIDERS: &[Provider] = &[
+    Provider {
+        name: "Apple",
+        url: "http://captive.apple.com/hotspot-detect.html",
+        expects: Expect::Body("Success"),
+    },
+    Provider {
+        name: "Microsoft",
+        url: "http://www.msftconnecttest.com/connecttest.txt",
+        expects: Expect::Body("Microsoft Connect Test"),
+    },
+    Provider {
+        name: "Ubuntu",
+        url: "http://connectivity-check.ubuntu.com",
+        expects: Expect::Empty,
+    },
+    Provider {
+        name: "Cloudflare",
+        url: "http://cp.cloudflare.com/generate_204",
+        expects: Expect::Empty,
+    },
+    Provider {
+        name: "Google",
+        url: "http://connectivitycheck.gstatic.com/generate_204",
+        expects: Expect::Empty,
+    },
+];
+
+/// The OS's own endpoint — the one this machine already talks to.
+fn os_native() -> &'static Provider {
+    let name = if cfg!(target_os = "macos") {
+        "Apple"
+    } else if cfg!(windows) {
+        "Microsoft"
+    } else {
+        "Ubuntu"
+    };
+    by_name(name).expect("native provider is in the table")
+}
+
+fn by_name(name: &str) -> Option<&'static Provider> {
+    let norm = |s: &str| s.to_lowercase();
+    PROVIDERS.iter().find(|p| norm(p.name) == norm(name))
+}
+
+/// Resolve the configured provider: a known name, "auto"/empty for the OS's
+/// own, anything else is ignored in favour of the default.
+fn primary(cfg: &Config) -> &'static Provider {
+    match cfg.http_probe_provider.as_str() {
+        "" | "auto" => os_native(),
+        name => by_name(name).unwrap_or_else(os_native),
+    }
+}
+
+/// A different operator for the second opinion, so one company's outage can't
+/// condemn the network.
+fn second_opinion(p: &Provider) -> &'static Provider {
+    if p.name == "Cloudflare" {
+        by_name("Google").unwrap()
+    } else {
+        by_name("Cloudflare").unwrap()
+    }
+}
+
+/// Classify one response. Pure, so the whole decision table is testable.
+pub fn classify(
+    expects: Expect,
+    status: u16,
+    location: Option<String>,
+    body: &str,
+    rtt_ms: f64,
+) -> FamilyProbe {
+    match status {
+        204 if body.trim().is_empty() => FamilyProbe::Ok(rtt_ms),
+        // A redirect is the classic portal move; so is HTTP 511, which exists
+        // precisely to mean "network sign-in required".
+        300..=399 | 511 => FamilyProbe::Captive(location),
+        200 => match expects {
+            Expect::Empty if body.trim().is_empty() => FamilyProbe::Ok(rtt_ms),
+            Expect::Body(needle) if body.contains(needle) => FamilyProbe::Ok(rtt_ms),
+            // The expected boring answer was replaced by *something* — whatever
+            // is intercepting HTTP is the diagnosis.
+            _ => FamilyProbe::Captive(location),
+        },
+        s => FamilyProbe::Fail(format!("HTTP {s}")),
+    }
+}
+
+/// Whether this machine has IPv6 that is *supposed* to work: a global address,
+/// not just the automatic link-local (fe80::) or a ULA-only setup.
+pub fn has_global_v6(addrs: &[String]) -> bool {
+    addrs.iter().any(|a| {
+        let Some(ip) = a
+            .split('/')
+            .next()
+            .and_then(|s| s.parse::<Ipv6Addr>().ok())
+        else {
+            return false;
+        };
+        let seg = ip.segments();
+        let link_local = (seg[0] & 0xffc0) == 0xfe80;
+        let unique_local = (seg[0] & 0xfe00) == 0xfc00;
+        !link_local && !unique_local && !ip.is_loopback() && !ip.is_unspecified()
+    })
+}
+
+/// One probe over one family-pinned client.
+async fn probe(client: &reqwest::Client, p: &Provider) -> FamilyProbe {
+    let start = Instant::now();
+    let resp = match client.get(p.url).send().await {
+        Ok(r) => r,
+        Err(e) => return FamilyProbe::Fail(short_reason(&e)),
+    };
+    let rtt_ms = start.elapsed().as_secs_f64() * 1000.0;
+    let status = resp.status().as_u16();
+    let location = resp
+        .headers()
+        .get(reqwest::header::LOCATION)
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_string);
+    // Only a prefix is needed to match the expected needle or detect a portal
+    // page; cap it so a hostile network can't feed us a huge body.
+    let mut body = Vec::new();
+    let mut stream = resp.bytes_stream();
+    while let Some(Ok(chunk)) = stream.next().await {
+        body.extend_from_slice(&chunk);
+        if body.len() >= 1024 {
+            break;
+        }
+    }
+    let body = String::from_utf8_lossy(&body);
+    classify(p.expects, status, location, &body, rtt_ms)
+}
+
+/// Compress reqwest's error chains into something a status line can carry.
+fn short_reason(e: &reqwest::Error) -> String {
+    if e.is_timeout() {
+        "timeout".to_string()
+    } else if e.is_connect() {
+        "connect failed".to_string()
+    } else {
+        "request failed".to_string()
+    }
+}
+
+/// Probe, and on a bad answer let an independent provider arbitrate.
+async fn probe_verified(
+    client: &reqwest::Client,
+    p: &'static Provider,
+) -> (FamilyProbe, Option<String>) {
+    let first = probe(client, p).await;
+    match first {
+        FamilyProbe::Ok(_) => (first, None),
+        _ => {
+            let sec = second_opinion(p);
+            match probe(client, sec).await {
+                FamilyProbe::Ok(ms) => (
+                    FamilyProbe::Ok(ms),
+                    Some(format!(
+                        "{} endpoint misbehaving — verified ok via {}",
+                        p.name, sec.name
+                    )),
+                ),
+                // Two independent operators agree: the finding stands.
+                _ => (first, None),
+            }
+        }
+    }
+}
+
+fn family_client(local: IpAddr) -> Option<reqwest::Client> {
+    reqwest::Client::builder()
+        .local_address(local)
+        .redirect(reqwest::redirect::Policy::none())
+        .timeout(std::time::Duration::from_secs(4))
+        .build()
+        .ok()
+}
+
+pub async fn run(state: Arc<Mutex<AppState>>, cfg: Config, changed: Arc<Notify>) {
+    // Binding the local address pins the family at connect time — no resolver
+    // surgery needed to test v4 and v6 separately.
+    let v4 = family_client(IpAddr::V4(Ipv4Addr::UNSPECIFIED));
+    let v6 = family_client(IpAddr::V6(Ipv6Addr::UNSPECIFIED));
+    let p = primary(&cfg);
+
+    let mut ticker = tokio::time::interval(cfg.http_probe_interval());
+    loop {
+        // Re-probe on the cadence, or immediately on a network change —
+        // captive detection matters most seconds after joining a network.
+        tokio::select! {
+            _ = ticker.tick() => {}
+            _ = changed.notified() => {}
+        }
+
+        let v6_applicable = {
+            let s = state.lock().unwrap();
+            has_global_v6(&s.netinfo.ipv6)
+        };
+
+        let (r4, note4) = match &v4 {
+            Some(c) => probe_verified(c, p).await,
+            None => (FamilyProbe::Fail("no v4 client".into()), None),
+        };
+        let (r6, note6) = if !v6_applicable {
+            (FamilyProbe::NotApplicable, None)
+        } else {
+            match &v6 {
+                Some(c) => probe_verified(c, p).await,
+                None => (FamilyProbe::Fail("no v6 client".into()), None),
+            }
+        };
+
+        let mut s = state.lock().unwrap();
+        // Mutate in place: the histories accumulate across probes.
+        if let FamilyProbe::Ok(ms) = r4 {
+            s.http.v4_hist.push(ms);
+        }
+        if let FamilyProbe::Ok(ms) = r6 {
+            s.http.v6_hist.push(ms);
+        }
+        s.http.provider = p.name.to_string();
+        s.http.v4 = r4;
+        s.http.v6 = r6;
+        s.http.note = note4.or(note6);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn is_ok(p: &FamilyProbe) -> bool {
+        matches!(p, FamilyProbe::Ok(_))
+    }
+
+    #[test]
+    fn classify_covers_both_endpoint_flavours() {
+        // The empty-204 flavour.
+        assert!(is_ok(&classify(Expect::Empty, 204, None, "", 10.0)));
+        assert!(is_ok(&classify(Expect::Empty, 200, None, "  \n", 10.0)));
+        // A body where none belongs: something is intercepting.
+        assert!(matches!(
+            classify(Expect::Empty, 200, None, "<html>Sign in</html>", 10.0),
+            FamilyProbe::Captive(None)
+        ));
+
+        // The known-answer flavour.
+        let apple = Expect::Body("Success");
+        assert!(is_ok(&classify(
+            apple,
+            200,
+            None,
+            "<HTML><BODY>Success</BODY></HTML>",
+            10.0
+        )));
+        assert!(matches!(
+            classify(apple, 200, None, "<html>Hotel Wi-Fi</html>", 10.0),
+            FamilyProbe::Captive(None)
+        ));
+        // A 204 is success even where a body was expected — nobody serves a
+        // sign-in page as an empty 204.
+        assert!(is_ok(&classify(apple, 204, None, "", 10.0)));
+    }
+
+    #[test]
+    fn redirects_and_511_read_as_captive_with_the_target_kept() {
+        let r = classify(
+            Expect::Empty,
+            302,
+            Some("http://portal.hotel/login".into()),
+            "",
+            10.0,
+        );
+        assert_eq!(
+            r,
+            FamilyProbe::Captive(Some("http://portal.hotel/login".into()))
+        );
+        assert!(matches!(
+            classify(Expect::Empty, 511, None, "", 10.0),
+            FamilyProbe::Captive(_)
+        ));
+    }
+
+    #[test]
+    fn server_errors_are_failures_not_portals() {
+        assert_eq!(
+            classify(Expect::Empty, 500, None, "oops", 10.0),
+            FamilyProbe::Fail("HTTP 500".into())
+        );
+    }
+
+    /// fe80:: (automatic, always present) and ULA must not make a v4-only LAN
+    /// read as "IPv6 broken".
+    #[test]
+    fn v6_applicability_requires_a_global_address() {
+        assert!(!has_global_v6(&[]));
+        assert!(!has_global_v6(&["fe80::1c2a:ffee/64".into()]));
+        assert!(!has_global_v6(&["fd00:abcd::5/64".into()]));
+        assert!(!has_global_v6(&["not-an-ip".into()]));
+        assert!(has_global_v6(&[
+            "fe80::1/64".into(),
+            "2a00:23c5:dd80:1::42/64".into()
+        ]));
+    }
+
+    #[test]
+    fn the_second_opinion_is_always_a_different_operator() {
+        for p in PROVIDERS {
+            assert_ne!(second_opinion(p).name, p.name);
+        }
+    }
+
+    #[test]
+    fn every_platform_has_a_native_provider() {
+        // Would panic if the table were missing this OS's entry.
+        let p = os_native();
+        assert!(!p.url.is_empty());
+    }
+}

--- a/src/collectors/logger.rs
+++ b/src/collectors/logger.rs
@@ -21,6 +21,8 @@ const HEADER: &str = "timestamp,category,subject,metric,value,unit\n";
 pub async fn run(state: Arc<Mutex<AppState>>, cfg: Config) {
     let mut ticker = tokio::time::interval(cfg.sample_interval());
     let mut file: Option<tokio::fs::File> = None;
+    // Timeline high-water mark: only events newer than this go into the CSV.
+    let mut events_seen: u64 = 0;
 
     loop {
         ticker.tick().await;
@@ -33,17 +35,31 @@ pub async fn run(state: Arc<Mutex<AppState>>, cfg: Config) {
                     Ok((f, path)) => {
                         file = Some(f);
                         let mut s = state.lock().unwrap();
+                        // The recording covers from now on; history that predates
+                        // it belongs to the events overlay, not this file.
+                        events_seen = s.events_total;
                         s.log = Some(LogStatus {
                             path: path.clone(),
                             rows: 0,
                             started: std::time::Instant::now(),
                         });
-                        s.notice = Some(format!("recording → {}", path.display()));
+                        // No transient notice: the footer-right "● rec →" and
+                        // the header REC badge are the live feedback, and the
+                        // notice slot must stay free for the analysis line.
+                        s.push_event(
+                            crate::verdict::Severity::Info,
+                            crate::app::EventCategory::Logging,
+                            format!("recording → {}", path.display()),
+                        );
                     }
                     Err(e) => {
                         let mut s = state.lock().unwrap();
                         s.logging_requested = false;
-                        s.notice = Some(format!("could not start recording: {e}"));
+                        s.notice_event(
+                            crate::verdict::Severity::Info,
+                            crate::app::EventCategory::Logging,
+                            format!("could not start recording: {e}"),
+                        );
                     }
                 }
                 continue; // first row on the next tick
@@ -55,11 +71,15 @@ pub async fn run(state: Arc<Mutex<AppState>>, cfg: Config) {
                 }
                 let mut s = state.lock().unwrap();
                 if let Some(status) = s.log.take() {
-                    s.notice = Some(format!(
-                        "recording stopped — {} rows → {}",
-                        status.rows,
-                        status.path.display()
-                    ));
+                    s.push_event(
+                        crate::verdict::Severity::Info,
+                        crate::app::EventCategory::Logging,
+                        format!(
+                            "recording stopped — {} rows → {}",
+                            status.rows,
+                            status.path.display()
+                        ),
+                    );
                 }
                 continue;
             }
@@ -71,7 +91,8 @@ pub async fn run(state: Arc<Mutex<AppState>>, cfg: Config) {
         let (body, rows) = {
             let s = state.lock().unwrap();
             let stamp = chrono::Local::now().to_rfc3339();
-            let body = format_rows(&s, &stamp);
+            let mut body = format_rows(&s, &stamp);
+            body.push_str(&format_events(&s, &stamp, &mut events_seen));
             let rows = body.lines().count() as u64;
             (body, rows)
         };
@@ -260,6 +281,25 @@ fn format_rows(s: &AppState, stamp: &str) -> String {
     out
 }
 
+/// Timeline events newer than the high-water mark, one row each. Events are
+/// text, not measurements, so the message rides in the value column (quoted)
+/// with the severity as the metric: `…,event,verdict,degraded,"▲ …",`.
+fn format_events(s: &AppState, stamp: &str, seen: &mut u64) -> String {
+    let mut out = String::new();
+    let new = (s.events_total.saturating_sub(*seen) as usize).min(s.events.len());
+    for e in s.events.iter().skip(s.events.len() - new) {
+        let _ = writeln!(
+            out,
+            "{stamp},event,{},{},{},",
+            e.category.label(),
+            e.severity.label(),
+            field(&e.message)
+        );
+    }
+    *seen = s.events_total;
+    out
+}
+
 /// Quote a CSV field when it contains anything that would break parsing.
 /// Target labels and process names are user- and system-supplied.
 fn field(v: &str) -> String {
@@ -307,6 +347,37 @@ mod tests {
         assert!(out.contains(",target,Cloudflare,rtt_ms,12.500,ms"));
         assert!(out.contains(",throughput,en0,down_bps,2048,B/s"));
         assert!(out.contains(",machine,,cpu_pct,"));
+    }
+
+    /// Events go to CSV exactly once, past a high-water mark, message quoted.
+    #[test]
+    fn events_drain_once_past_the_watermark() {
+        let mut s = AppState::new(vec![]);
+        s.push_event(
+            crate::verdict::Severity::Degraded,
+            crate::app::EventCategory::Analysis,
+            "▲ gateway, unresponsive".into(),
+        );
+
+        let mut seen = 0;
+        let out = format_events(&s, "T", &mut seen);
+        assert_eq!(
+            out,
+            "T,event,analysis,degraded,\"▲ gateway, unresponsive\",\n"
+        );
+        assert_eq!(seen, 1);
+
+        // Nothing new: nothing written, even though the event is still held.
+        assert!(format_events(&s, "T", &mut seen).is_empty());
+
+        s.push_event(
+            crate::verdict::Severity::Info,
+            crate::app::EventCategory::Network,
+            "VPN down".into(),
+        );
+        let out = format_events(&s, "T", &mut seen);
+        assert_eq!(out.lines().count(), 1);
+        assert!(out.contains("network,info,VPN down"));
     }
 
     /// A label containing a comma must not shift every later column.

--- a/src/collectors/mod.rs
+++ b/src/collectors/mod.rs
@@ -5,14 +5,17 @@
 pub mod discovery;
 pub mod dns;
 pub mod hopmon;
+pub mod http;
 pub mod logger;
 pub mod ndt7;
 pub mod netinfo;
 pub mod ping;
 pub mod procbw;
+pub mod resolve;
 pub mod signal;
 pub mod speedtest;
 pub mod throughput;
 pub mod traceroute;
 pub mod vitals;
+pub mod web;
 pub mod wifi;

--- a/src/collectors/netinfo.rs
+++ b/src/collectors/netinfo.rs
@@ -109,10 +109,9 @@ pub async fn run(state: Arc<Mutex<AppState>>, refresh: Arc<Notify>, changed: Arc
                 // A tunnel coming up or down changes the identity too; name the
                 // VPN rather than reporting a bare interface swap.
                 let message = match (had_tunnel, s.netinfo.tunnel.is_some()) {
-                    (false, true) => format!(
-                        "VPN up — {}",
-                        s.netinfo.tunnel_label().unwrap_or_default()
-                    ),
+                    (false, true) => {
+                        format!("VPN up — {}", s.netinfo.tunnel_label().unwrap_or_default())
+                    }
                     (true, false) => "VPN down".to_string(),
                     // The SSID isn't known yet (the Wi-Fi probe is slow); the
                     // gateway is the most identifying fact available now, and

--- a/src/collectors/netinfo.rs
+++ b/src/collectors/netinfo.rs
@@ -16,11 +16,31 @@ pub async fn run(state: Arc<Mutex<AppState>>, refresh: Arc<Notify>, changed: Arc
     // table, so the answer is cached per tunnel device rather than redone every
     // tick.
     let mut vendor_cache: Option<(String, String)> = None;
+    // Whether the default route has vanished entirely (Wi-Fi switched off,
+    // cable pulled) — a different situation from moving to another network.
+    let mut link_lost = false;
     loop {
         // Re-probe on the timer or when the user presses 'r'.
         tokio::select! {
             _ = ticker.tick() => {}
             _ = refresh.notified() => {}
+        }
+        if netdev::get_default_interface().is_err() {
+            let mut s = state.lock().unwrap();
+            if !link_lost && !s.netinfo.iface.is_empty() {
+                link_lost = true;
+                let medium = s.netinfo.medium;
+                s.notice_event(
+                    crate::verdict::Severity::Down,
+                    crate::app::EventCategory::Network,
+                    match medium {
+                        LinkMedium::WiFi => "link lost — Wi-Fi is off or disconnected".to_string(),
+                        m if m.is_wired() => "link lost — cable unplugged?".to_string(),
+                        _ => "link lost — no default route".to_string(),
+                    },
+                );
+            }
+            continue;
         }
         if let Ok(iface) = netdev::get_default_interface() {
             let mut info = build(&iface);
@@ -58,15 +78,70 @@ pub async fn run(state: Arc<Mutex<AppState>>, refresh: Arc<Notify>, changed: Arc
             let was = s.netinfo.identity();
             let now = info.identity();
             let prev_wifi = s.netinfo.wifi.take();
-            let moved = !s.netinfo.iface.is_empty() && was != now;
+            let prev_dns = s.netinfo.dns.clone();
+            let had_tunnel = s.netinfo.tunnel.is_some();
+            let had_info = !s.netinfo.iface.is_empty();
+            let moved = had_info && was != now;
             s.netinfo = info;
             s.netinfo.wifi = if moved { None } else { prev_wifi };
+            let restored = std::mem::take(&mut link_lost);
+            if restored {
+                // The link is back (same network or not): stats accumulated
+                // while it was down describe the outage, not the path — left
+                // alone they'd keep the panel red for minutes.
+                s.reset_quality_stats();
+                let message = format!(
+                    "link restored → {} — connection stats reset",
+                    s.netinfo.iface
+                );
+                s.push_event(
+                    crate::verdict::Severity::Info,
+                    crate::app::EventCategory::Network,
+                    message,
+                );
+            }
             if moved {
                 // Everything derived from the old network — discovered hops, the
-                // path monitor, which interface throughput reads — is now stale.
+                // path monitor, which interface throughput reads — is now stale,
+                // and that includes every accumulated latency/loss figure.
                 s.net_change_seq += 1;
-                s.notice = Some(format!("network changed → {}", s.netinfo.iface));
+                s.reset_quality_stats();
+                // A tunnel coming up or down changes the identity too; name the
+                // VPN rather than reporting a bare interface swap.
+                let message = match (had_tunnel, s.netinfo.tunnel.is_some()) {
+                    (false, true) => format!(
+                        "VPN up — {}",
+                        s.netinfo.tunnel_label().unwrap_or_default()
+                    ),
+                    (true, false) => "VPN down".to_string(),
+                    // The SSID isn't known yet (the Wi-Fi probe is slow); the
+                    // gateway is the most identifying fact available now, and
+                    // the wifi collector names the network moments later.
+                    _ => format!(
+                        "network changed → {}{}",
+                        s.netinfo.iface,
+                        if s.netinfo.gateway_ip != "-" && !s.netinfo.gateway_ip.is_empty() {
+                            format!(" · gateway {}", s.netinfo.gateway_ip)
+                        } else {
+                            String::new()
+                        }
+                    ),
+                };
+                s.notice_event(
+                    crate::verdict::Severity::Info,
+                    crate::app::EventCategory::Network,
+                    message,
+                );
                 changed.notify_waiters();
+            } else if had_info && s.netinfo.dns != prev_dns {
+                // Same network, new resolvers (DHCP renewal, profile change) —
+                // invisible in any average, classic "it broke at 3pm" material.
+                let message = format!("DNS servers changed → {}", s.netinfo.dns.join(", "));
+                s.push_event(
+                    crate::verdict::Severity::Info,
+                    crate::app::EventCategory::Network,
+                    message,
+                );
             }
         }
     }
@@ -117,6 +192,7 @@ fn build(iface: &netdev::Interface) -> NetInfo {
     let medium = classify(iface);
     NetInfo {
         iface: counter_name(iface),
+        iface_index: iface.index,
         iface_label: iface.friendly_name.clone().unwrap_or_default(),
         ipv4,
         ipv6,

--- a/src/collectors/netinfo.rs
+++ b/src/collectors/netinfo.rs
@@ -19,12 +19,38 @@ pub async fn run(state: Arc<Mutex<AppState>>, refresh: Arc<Notify>, changed: Arc
     // Whether the default route has vanished entirely (Wi-Fi switched off,
     // cable pulled) — a different situation from moving to another network.
     let mut link_lost = false;
+    // Physical interfaces seen last tick, for plug/unplug events. `None` until
+    // the first pass so startup doesn't announce every existing adapter.
+    let mut known_ifaces: Option<std::collections::HashMap<String, LinkMedium>> = None;
     loop {
         // Re-probe on the timer or when the user presses 'r'.
         tokio::select! {
             _ = ticker.tick() => {}
             _ = refresh.notified() => {}
         }
+
+        // Announce physical interfaces appearing or disappearing even when the
+        // default route doesn't move. "Cable plugged in but the OS still
+        // routes via Wi-Fi" is otherwise invisible — and it's the classic way
+        // a USB dongle quietly fails to take over.
+        let current: std::collections::HashMap<String, LinkMedium> =
+            physical_interfaces().into_iter().collect();
+        if let Some(prev) = known_ifaces.as_ref() {
+            let default_name = state.lock().unwrap().netinfo.iface.clone();
+            let messages = iface_changes(prev, &current, &default_name);
+            if !messages.is_empty() {
+                let mut s = state.lock().unwrap();
+                for m in messages {
+                    s.push_event(
+                        crate::verdict::Severity::Info,
+                        crate::app::EventCategory::Network,
+                        m,
+                    );
+                }
+            }
+        }
+        known_ifaces = Some(current);
+
         if netdev::get_default_interface().is_err() {
             let mut s = state.lock().unwrap();
             if !link_lost && !s.netinfo.iface.is_empty() {
@@ -212,6 +238,56 @@ fn build(iface: &netdev::Interface) -> NetInfo {
         tunnel_is_split: false,
         wifi: None, // filled in by the caller for Wi-Fi links
     }
+}
+
+/// Physical interfaces worth announcing: up, addressed, and a medium a human
+/// plugs or toggles (virtual/tunnel devices have their own events).
+fn physical_interfaces() -> Vec<(String, LinkMedium)> {
+    netdev::get_interfaces()
+        .iter()
+        .filter(|i| !i.ipv4.is_empty() || !i.ipv6.is_empty())
+        .map(|i| (counter_name(i), classify(i)))
+        .filter(|(_, m)| {
+            matches!(
+                m,
+                LinkMedium::WiFi | LinkMedium::Ethernet | LinkMedium::Cellular
+            )
+        })
+        .collect()
+}
+
+/// Messages for the diff between two interface snapshots. Pure, so the wording
+/// rules are testable: an arriving interface that is NOT the default route
+/// says so — that is the whole warning.
+fn iface_changes(
+    prev: &std::collections::HashMap<String, LinkMedium>,
+    current: &std::collections::HashMap<String, LinkMedium>,
+    default_name: &str,
+) -> Vec<String> {
+    let mut out = Vec::new();
+    for (name, medium) in current {
+        if !prev.contains_key(name) {
+            let note = if name != default_name && !default_name.is_empty() {
+                format!(" — default route still {default_name}")
+            } else {
+                String::new()
+            };
+            out.push(format!(
+                "interface connected: {name} ({}){note}",
+                medium.label()
+            ));
+        }
+    }
+    for (name, medium) in prev {
+        if !current.contains_key(name) {
+            out.push(format!(
+                "interface disconnected: {name} ({})",
+                medium.label()
+            ));
+        }
+    }
+    out.sort();
+    out
 }
 
 /// The interface name that `sysinfo`'s counters are keyed on.
@@ -454,7 +530,41 @@ fn tunnel_vendor(iface_name: String) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{Ipv4Addr, Ipv6Addr, is_tunnel_name, vendor_from_addrs};
+    use super::{Ipv4Addr, Ipv6Addr, iface_changes, is_tunnel_name, vendor_from_addrs};
+
+    /// The Ubuntu USB-dongle lesson: a wired interface coming up while Wi-Fi
+    /// keeps the default route must be announced — with the "default route
+    /// still Wi-Fi" warning, because that is the whole problem.
+    #[test]
+    fn hotplugged_interface_warns_when_the_route_does_not_follow() {
+        use crate::app::LinkMedium;
+        use std::collections::HashMap;
+        let wifi_only: HashMap<String, LinkMedium> =
+            [("wlp2s0".to_string(), LinkMedium::WiFi)].into();
+        let both: HashMap<String, LinkMedium> = [
+            ("wlp2s0".to_string(), LinkMedium::WiFi),
+            ("enx00e04c".to_string(), LinkMedium::Ethernet),
+        ]
+        .into();
+
+        // Plugged in, route still on Wi-Fi: say so.
+        let msgs = iface_changes(&wifi_only, &both, "wlp2s0");
+        assert_eq!(msgs.len(), 1);
+        assert!(msgs[0].contains("interface connected: enx00e04c"));
+        assert!(msgs[0].contains("default route still wlp2s0"));
+
+        // Plugged in and it IS the default: no warning clause.
+        let msgs = iface_changes(&wifi_only, &both, "enx00e04c");
+        assert!(!msgs[0].contains("default route still"));
+
+        // Unplugged: announced too.
+        let msgs = iface_changes(&both, &wifi_only, "wlp2s0");
+        assert_eq!(msgs.len(), 1);
+        assert!(msgs[0].contains("interface disconnected: enx00e04c"));
+
+        // No change, no chatter.
+        assert!(iface_changes(&both, &both, "wlp2s0").is_empty());
+    }
 
     /// Real values observed on a Mac running WARP with NordVPN also installed
     /// and its helpers resident: the interface must decide, not the process list.

--- a/src/collectors/ping.rs
+++ b/src/collectors/ping.rs
@@ -1,7 +1,7 @@
 //! ICMP quality collector. One async task per target, each with its own
-//! [`surge_ping::Pinger`] sharing a single [`Client`]. Uses unprivileged datagram
-//! ICMP sockets (`Config::default()` → `SOCK_DGRAM`), so no root is required on
-//! macOS or Linux. Targets can be added at runtime via [`spawn_for`].
+//! [`surge_ping::Pinger`] sharing a per-family [`Client`]. Uses unprivileged
+//! datagram ICMP sockets (`SOCK_DGRAM`), so no root is required on macOS or
+//! Linux. Targets can be added at runtime via [`spawn_for`].
 
 use std::net::IpAddr;
 use std::sync::{Arc, Mutex};
@@ -11,16 +11,68 @@ use surge_ping::{Client, PingIdentifier, PingSequence};
 use crate::app::AppState;
 use crate::config::Config;
 
+/// One ICMP client per address family. A v4 client cannot ping a v6 address
+/// (a lesson from v6-only carrier hotspots, where every AAAA-resolved target
+/// silently showed 100% loss), so both are opened up front and each target
+/// picks by its family.
+#[derive(Clone, Default)]
+pub struct Clients {
+    pub v4: Option<Arc<Client>>,
+    pub v6: Option<Arc<Client>>,
+}
+
+impl Clients {
+    /// Open both family clients. Returns the clients plus the v4 error when
+    /// even IPv4 ICMP is unavailable — that is the "latency features are dead"
+    /// condition; a missing v6 client just means v6 targets can't be probed.
+    pub fn open() -> (Self, Option<String>) {
+        let v4 = Client::new(&surge_ping::Config::default());
+        let v4_err = v4.as_ref().err().map(|e| e.to_string());
+        let v6 = Client::new(
+            &surge_ping::Config::builder()
+                .kind(surge_ping::ICMP::V6)
+                .build(),
+        );
+        (
+            Self {
+                v4: v4.ok().map(Arc::new),
+                v6: v6.ok().map(Arc::new),
+            },
+            v4_err,
+        )
+    }
+
+    /// The client that can reach this address, if any.
+    pub fn for_addr(&self, addr: IpAddr) -> Option<Arc<Client>> {
+        match addr {
+            IpAddr::V4(_) => self.v4.clone(),
+            IpAddr::V6(_) => self.v6.clone(),
+        }
+    }
+
+    pub fn available(&self) -> bool {
+        self.v4.is_some() || self.v6.is_some()
+    }
+}
+
 /// Spawn a ping loop for a target identified by its stable `id`. The task looks
 /// the target up by id each tick, so it self-terminates if the target is
 /// removed and is unaffected by other targets being added/deleted.
 pub fn spawn_for(
     state: Arc<Mutex<AppState>>,
-    client: Arc<Client>,
+    clients: Clients,
     cfg: Config,
     id: u64,
     addr: IpAddr,
 ) {
+    let Some(client) = clients.for_addr(addr) else {
+        // No client for this family: say so once rather than accumulating
+        // losses that read as a network fault.
+        let mut s = state.lock().unwrap();
+        let family = if addr.is_ipv6() { "IPv6" } else { "IPv4" };
+        s.notice = Some(format!("no {family} ICMP socket — cannot probe {addr}"));
+        return;
+    };
     tokio::spawn(async move {
         let mut pinger = client
             .pinger(addr, PingIdentifier((id as u16).wrapping_add(1)))
@@ -39,26 +91,36 @@ pub fn spawn_for(
             ticker.tick().await;
             seq = seq.wrapping_add(1);
             let result = pinger.ping(PingSequence(seq), &payload).await;
-            let mut s = state.lock().unwrap();
-            // Look up by id; if the target was deleted, end this task.
-            let Some(target) = s.targets.iter_mut().find(|t| t.id == id) else {
-                break;
+            let rebind = {
+                let mut s = state.lock().unwrap();
+                // Look up by id; if the target was deleted, end this task.
+                let Some(target) = s.targets.iter_mut().find(|t| t.id == id) else {
+                    break;
+                };
+                match result {
+                    Ok((_pkt, dur)) => target.record_reply(dur.as_secs_f64() * 1000.0),
+                    Err(_) => target.record_loss(),
+                }
+                // Re-resolution can move a hostname target's address under us
+                // (CDNs answer per network); the pinger is bound to an address,
+                // so hand over to a fresh task aimed at the new one.
+                (target.addr != addr).then_some(target.addr)
             };
-            match result {
-                Ok((_pkt, dur)) => target.record_reply(dur.as_secs_f64() * 1000.0),
-                Err(_) => target.record_loss(),
+            if let Some(new_addr) = rebind {
+                spawn_for(state.clone(), clients.clone(), cfg.clone(), id, new_addr);
+                break;
             }
         }
     });
 }
 
 /// Spawn ping loops for all targets currently in the state.
-pub fn spawn_all(state: Arc<Mutex<AppState>>, client: Arc<Client>, cfg: Config) {
+pub fn spawn_all(state: Arc<Mutex<AppState>>, clients: Clients, cfg: Config) {
     let snapshot: Vec<(u64, IpAddr)> = {
         let s = state.lock().unwrap();
         s.targets.iter().map(|t| (t.id, t.addr)).collect()
     };
     for (id, addr) in snapshot {
-        spawn_for(state.clone(), client.clone(), cfg.clone(), id, addr);
+        spawn_for(state.clone(), clients.clone(), cfg.clone(), id, addr);
     }
 }

--- a/src/collectors/resolve.rs
+++ b/src/collectors/resolve.rs
@@ -1,0 +1,80 @@
+//! Hostname re-resolution for name-added targets.
+//!
+//! A CDN answers differently per network, so bbc.co.uk's address is a property
+//! of *where you are*: it is re-resolved the moment the network changes (the
+//! event that actually flips the answer) and on a slow cadence otherwise —
+//! 60 s, matched to typical CDN TTLs; faster would mostly re-read the resolver
+//! cache. Never per-ping, which would put a DNS query in front of every
+//! latency sample.
+//!
+//! When the answer changes, the target keeps its identity but its stats reset
+//! (latency to the old CDN node says nothing about the new one) and the move
+//! lands on the timeline — making "did my network degrade, or did the CDN move
+//! me?" answerable at a glance.
+
+use std::net::IpAddr;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use tokio::sync::Notify;
+
+use crate::app::AppState;
+
+const PERIODIC: Duration = Duration::from_secs(60);
+
+pub async fn run(state: Arc<Mutex<AppState>>, changed: Arc<Notify>) {
+    let mut ticker = tokio::time::interval(PERIODIC);
+    ticker.tick().await; // the interval fires immediately; targets don't exist yet
+    loop {
+        // Event-driven on network change — the moment the CDN answer actually
+        // flips — with the slow periodic sweep covering DNS-based failover.
+        tokio::select! {
+            _ = ticker.tick() => {}
+            _ = changed.notified() => {}
+        }
+
+        let named: Vec<(u64, String, IpAddr)> = {
+            let s = state.lock().unwrap();
+            s.targets
+                .iter()
+                .filter_map(|t| t.hostname.clone().map(|h| (t.id, h, t.addr)))
+                .collect()
+        };
+
+        for (id, host, current) in named {
+            let Ok(mut addrs) = tokio::net::lookup_host((host.as_str(), 0)).await else {
+                continue; // resolution failing is the DNS story, told elsewhere
+            };
+            // Prefer an answer in the same family as the current address, so a
+            // dual-stack answer doesn't flap the target between families.
+            let same_family = addrs.find(|a| a.ip().is_ipv4() == current.is_ipv4());
+            let new = match same_family {
+                Some(sa) => sa.ip(),
+                None => match tokio::net::lookup_host((host.as_str(), 0))
+                    .await
+                    .ok()
+                    .and_then(|mut a| a.next())
+                {
+                    Some(sa) => sa.ip(),
+                    None => continue,
+                },
+            };
+            if new == current {
+                continue;
+            }
+
+            let mut s = state.lock().unwrap();
+            let Some(t) = s.targets.iter_mut().find(|t| t.id == id) else {
+                continue;
+            };
+            t.addr = new; // the ping task notices and rebinds
+            t.reset();
+            let message = format!("{host} → {new} (was {current}) — stats reset");
+            s.push_event(
+                crate::verdict::Severity::Info,
+                crate::app::EventCategory::Network,
+                message,
+            );
+        }
+    }
+}

--- a/src/collectors/speedtest.rs
+++ b/src/collectors/speedtest.rs
@@ -144,16 +144,29 @@ pub async fn run(state: Arc<Mutex<AppState>>, trigger: Arc<Notify>, cfg: crate::
                 s.speed_total += 1;
 
                 s.speedtest.status = SpeedStatus::Done;
-                s.speedtest.provider = r.provider;
+                s.speedtest.provider = r.provider.clone();
                 s.speedtest.down_mbps = Some(r.down_mbps);
                 s.speedtest.up_mbps = Some(r.up_mbps);
                 s.speedtest.idle_latency_ms = r.idle_ms;
                 s.speedtest.loaded_latency_ms = r.loaded_ms;
                 s.speedtest.phase = "done".to_string();
+                s.push_event(
+                    crate::verdict::Severity::Info,
+                    crate::app::EventCategory::Speedtest,
+                    format!(
+                        "speed test: {:.0}↓ / {:.0}↑ Mbps ({})",
+                        r.down_mbps, r.up_mbps, r.provider
+                    ),
+                );
             }
             Err(e) => {
                 s.speedtest.status = SpeedStatus::Failed(e.clone());
                 s.speedtest.phase = format!("failed: {e}");
+                s.push_event(
+                    crate::verdict::Severity::Info,
+                    crate::app::EventCategory::Speedtest,
+                    format!("speed test failed: {e}"),
+                );
             }
         }
     }

--- a/src/collectors/web.rs
+++ b/src/collectors/web.rs
@@ -1,0 +1,216 @@
+//! Per-target HTTP(S) reachability and time-to-first-byte.
+//!
+//! The ICMP view says how far away a target is; this says how its *web service*
+//! is doing — a different thing, and for a hostname target (bbc.co.uk) usually
+//! the thing the user actually cares about. Not every target serves HTTP:
+//! 8.8.8.8 refuses, mid-path hops time out, and neither is a fault. Each target
+//! is classified once ([`WebStatus`]) and only demonstrated web servers are
+//! held to a standard afterwards.
+//!
+//! One HEAD request, redirects not followed, body discarded, any HTTP status
+//! counts as up. Certificate errors are tolerated (`danger_accept_invalid_certs`)
+//! because this is a timing instrument that sends nothing sensitive and reads
+//! nothing back — an IP-literal probe of 9.9.9.9 should measure the handshake,
+//! not fail on a name mismatch.
+
+use std::net::IpAddr;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use crate::app::{AppState, WebStatus};
+
+/// How often a confirmed web server is timed.
+const WEB_EVERY: Duration = Duration::from_secs(15);
+/// How often a NoService / Filtered verdict is re-examined.
+const RECHECK_EVERY: Duration = Duration::from_secs(600);
+/// Unclassified targets retry quickly until they land in a bucket.
+const UNKNOWN_EVERY: Duration = Duration::from_secs(10);
+
+/// What one probe attempt observed.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Outcome {
+    /// Any HTTP response at all, however unhappy its status code.
+    Response,
+    /// Connection actively refused — proof of reachability, absence of service.
+    Refused,
+    /// Nothing came back at all.
+    Timeout,
+}
+
+/// The state machine, pure so the whole table is testable. `icmp_ok` is
+/// whether ICMP to the same target currently works — the only thing that can
+/// disambiguate a timeout (filtered web vs host simply down).
+pub fn transition(status: WebStatus, outcome: Outcome, icmp_ok: bool) -> WebStatus {
+    match (status, outcome) {
+        (_, Outcome::Response) => WebStatus::Web,
+        // A demonstrated web server keeps its status on failure — the failure
+        // count, not a reclassification, carries "it stopped answering".
+        (WebStatus::Web, _) => WebStatus::Web,
+        (_, Outcome::Refused) => WebStatus::NoService,
+        (_, Outcome::Timeout) if icmp_ok => WebStatus::Filtered,
+        // Host unreachable at every layer: nothing web-specific to conclude.
+        (status, Outcome::Timeout) => status,
+    }
+}
+
+/// The URL a target is probed at: the hostname when it was added as one
+/// (SNI + certificates + CDN routing all need it), else the bare address.
+pub fn probe_url(hostname: Option<&str>, addr: IpAddr) -> String {
+    match (hostname, addr) {
+        (Some(h), _) => format!("https://{h}/"),
+        (None, IpAddr::V6(v6)) => format!("https://[{v6}]/"),
+        (None, IpAddr::V4(v4)) => format!("https://{v4}/"),
+    }
+}
+
+/// Walk an error chain looking for a definitive connection refusal.
+fn is_refused(e: &reqwest::Error) -> bool {
+    let mut source: Option<&(dyn std::error::Error + 'static)> = Some(e);
+    while let Some(err) = source {
+        if let Some(io) = err.downcast_ref::<std::io::Error>()
+            && io.kind() == std::io::ErrorKind::ConnectionRefused
+        {
+            return true;
+        }
+        source = err.source();
+    }
+    false
+}
+
+async fn probe(client: &reqwest::Client, url: &str) -> (Outcome, f64) {
+    let start = Instant::now();
+    let result = client.head(url).send().await;
+    let ms = start.elapsed().as_secs_f64() * 1000.0;
+    match result {
+        Ok(_) => (Outcome::Response, ms),
+        Err(e) if is_refused(&e) => (Outcome::Refused, ms),
+        Err(_) => (Outcome::Timeout, ms),
+    }
+}
+
+pub async fn run(state: Arc<Mutex<AppState>>) {
+    let Ok(client) = reqwest::Client::builder()
+        .danger_accept_invalid_certs(true)
+        .redirect(reqwest::redirect::Policy::none())
+        .timeout(Duration::from_secs(4))
+        .build()
+    else {
+        return;
+    };
+
+    // Per-target schedule, keyed by stable id; entries for deleted targets
+    // just stop being consulted.
+    let mut due: std::collections::HashMap<u64, Instant> = std::collections::HashMap::new();
+    let mut ticker = tokio::time::interval(Duration::from_secs(5));
+    loop {
+        ticker.tick().await;
+        let now = Instant::now();
+
+        // Snapshot who needs probing. Hops are path infrastructure, not web
+        // destinations; the gateway and the user's targets are fair game.
+        let candidates: Vec<(u64, Option<String>, IpAddr)> = {
+            let s = state.lock().unwrap();
+            s.targets
+                .iter()
+                .filter(|t| !t.is_path_hop())
+                .map(|t| (t.id, t.hostname.clone(), t.addr))
+                .collect()
+        };
+
+        // Probe everything due concurrently: serially, one dead target's 4s
+        // timeout would delay every probe queued behind it.
+        let probes = candidates
+            .into_iter()
+            .filter(|(id, _, _)| !due.get(id).is_some_and(|d| *d > now))
+            .map(|(id, hostname, addr)| {
+                let client = client.clone();
+                async move {
+                    let url = probe_url(hostname.as_deref(), addr);
+                    let (outcome, ms) = probe(&client, &url).await;
+                    (id, outcome, ms)
+                }
+            });
+        let results = futures_util::future::join_all(probes).await;
+
+        for (id, outcome, ms) in results {
+            let mut s = state.lock().unwrap();
+            let Some(t) = s.targets.iter_mut().find(|t| t.id == id) else {
+                continue;
+            };
+            let icmp_ok =
+                t.window.len() >= 5 && t.recent_loss_pct(crate::verdict::thresholds::RECENT) < 50.0;
+            let next = transition(t.web.status, outcome, icmp_ok);
+            t.web.status = next;
+            match outcome {
+                Outcome::Response => {
+                    t.web.last_ttfb_ms = Some(ms);
+                    t.web.hist.push(ms);
+                    t.web.fails = 0;
+                }
+                _ => {
+                    t.web.last_ttfb_ms = None;
+                    if next == WebStatus::Web {
+                        t.web.fails += 1;
+                    }
+                }
+            }
+            due.insert(
+                id,
+                now + match next {
+                    WebStatus::Web => WEB_EVERY,
+                    WebStatus::Unknown => UNKNOWN_EVERY,
+                    WebStatus::NoService | WebStatus::Filtered => RECHECK_EVERY,
+                },
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::Ipv4Addr;
+
+    #[test]
+    fn absence_of_a_web_server_is_a_fact_not_a_fault() {
+        // 8.8.8.8-style: reachable, refuses — classified and left alone.
+        let s = transition(WebStatus::Unknown, Outcome::Refused, true);
+        assert_eq!(s, WebStatus::NoService);
+        // Corporate-firewall-style: ping answers, TCP vanishes.
+        let s = transition(WebStatus::Unknown, Outcome::Timeout, true);
+        assert_eq!(s, WebStatus::Filtered);
+        // Host entirely down: a timeout proves nothing about web capability.
+        let s = transition(WebStatus::Unknown, Outcome::Timeout, false);
+        assert_eq!(s, WebStatus::Unknown);
+    }
+
+    #[test]
+    fn a_demonstrated_server_is_held_to_its_standard() {
+        // Once Web, always Web — failures accumulate on the counter instead,
+        // because "it answered before and stopped" is the actual finding.
+        assert_eq!(
+            transition(WebStatus::Web, Outcome::Timeout, true),
+            WebStatus::Web
+        );
+        assert_eq!(
+            transition(WebStatus::Web, Outcome::Refused, true),
+            WebStatus::Web
+        );
+        // And any bucket recovers the moment a response arrives.
+        for from in [WebStatus::NoService, WebStatus::Filtered, WebStatus::Unknown] {
+            assert_eq!(transition(from, Outcome::Response, false), WebStatus::Web);
+        }
+    }
+
+    #[test]
+    fn probe_urls_prefer_the_hostname_and_bracket_v6() {
+        let v4: IpAddr = Ipv4Addr::new(1, 1, 1, 1).into();
+        assert_eq!(
+            probe_url(Some("bbc.co.uk"), v4),
+            "https://bbc.co.uk/"
+        );
+        assert_eq!(probe_url(None, v4), "https://1.1.1.1/");
+        let v6: IpAddr = "2606:4700::1111".parse().unwrap();
+        assert_eq!(probe_url(None, v6), "https://[2606:4700::1111]/");
+    }
+}

--- a/src/collectors/web.rs
+++ b/src/collectors/web.rs
@@ -197,7 +197,11 @@ mod tests {
             WebStatus::Web
         );
         // And any bucket recovers the moment a response arrives.
-        for from in [WebStatus::NoService, WebStatus::Filtered, WebStatus::Unknown] {
+        for from in [
+            WebStatus::NoService,
+            WebStatus::Filtered,
+            WebStatus::Unknown,
+        ] {
             assert_eq!(transition(from, Outcome::Response, false), WebStatus::Web);
         }
     }
@@ -205,10 +209,7 @@ mod tests {
     #[test]
     fn probe_urls_prefer_the_hostname_and_bracket_v6() {
         let v4: IpAddr = Ipv4Addr::new(1, 1, 1, 1).into();
-        assert_eq!(
-            probe_url(Some("bbc.co.uk"), v4),
-            "https://bbc.co.uk/"
-        );
+        assert_eq!(probe_url(Some("bbc.co.uk"), v4), "https://bbc.co.uk/");
         assert_eq!(probe_url(None, v4), "https://1.1.1.1/");
         let v6: IpAddr = "2606:4700::1111".parse().unwrap();
         assert_eq!(probe_url(None, v6), "https://[2606:4700::1111]/");

--- a/src/collectors/wifi.rs
+++ b/src/collectors/wifi.rs
@@ -15,6 +15,11 @@ pub async fn run(state: Arc<Mutex<AppState>>, refresh: Arc<Notify>) {
     // expensive probe on non-Wi-Fi links.
     tokio::time::sleep(Duration::from_secs(1)).await;
 
+    // Tracked here rather than in state: a network change clears the state's
+    // wifi details, and it's exactly across such changes that "which SSID did
+    // we land on" is worth an event.
+    let mut last_ssid: Option<String> = None;
+
     let mut ticker = tokio::time::interval(Duration::from_secs(60));
     loop {
         // Re-probe on the timer or when the user presses 'r'.
@@ -29,7 +34,21 @@ pub async fn run(state: Arc<Mutex<AppState>>, refresh: Arc<Notify>) {
         }
 
         if let Some(w) = crate::platform::wifi_details().await {
-            state.lock().unwrap().netinfo.wifi = Some(w);
+            let mut s = state.lock().unwrap();
+            let known = !w.ssid.is_empty() && !w.ssid.contains("redacted");
+            if known {
+                if let Some(prev) = last_ssid.as_deref()
+                    && prev != w.ssid
+                {
+                    s.push_event(
+                        crate::verdict::Severity::Info,
+                        crate::app::EventCategory::Wifi,
+                        format!("Wi-Fi network → {}", w.ssid),
+                    );
+                }
+                last_ssid = Some(w.ssid.clone());
+            }
+            s.netinfo.wifi = Some(w);
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -60,6 +60,16 @@ pub struct Config {
     /// Name looked up when probing resolvers. A widely cached name measures what
     /// applications actually experience; something obscure measures recursion.
     pub dns_probe_name: String,
+    /// HTTP connectivity-check endpoint: "auto" uses this OS's own (Apple /
+    /// Microsoft / Ubuntu — the machine already polls it, so octomon adds no
+    /// new party learning it is online); or name one of "apple", "microsoft",
+    /// "ubuntu", "cloudflare", "google". A failing answer is verified against a
+    /// second, independent provider before any finding is raised.
+    pub http_probe_provider: String,
+    /// How often the HTTP reachability probe runs, in milliseconds.
+    pub http_probe_interval_ms: u64,
+    /// Whether the first-run explainer has been shown (set automatically).
+    pub explainer_seen: bool,
     /// Glyphs used to plot chart lines: "braille", "halfblock" or "dot".
     ///
     /// Braille packs 2x4 dots into one cell and is what the charts are drawn
@@ -96,6 +106,9 @@ impl Default for Config {
             dns_interval_ms: 5000,
             dns_timeout_ms: 2000,
             dns_probe_name: "example.com".to_string(),
+            http_probe_provider: "auto".to_string(),
+            http_probe_interval_ms: 12_000,
+            explainer_seen: false,
             graph_marker: "braille".to_string(),
         }
     }
@@ -128,6 +141,9 @@ impl Config {
     }
     pub fn dns_timeout(&self) -> Duration {
         Duration::from_millis(self.dns_timeout_ms.max(100))
+    }
+    pub fn http_probe_interval(&self) -> Duration {
+        Duration::from_millis(self.http_probe_interval_ms.max(2000))
     }
 
     /// Chart marker, falling back to braille for an unrecognised value rather
@@ -199,12 +215,22 @@ impl Config {
     /// Update just the selected provider in the on-disk config (best-effort),
     /// preserving other settings.
     pub fn persist_provider(name: &str) {
+        Self::update_on_disk(|cfg| cfg.speedtest_provider = name.to_string());
+    }
+
+    /// Record that the first-run explainer has been shown (best-effort).
+    pub fn persist_explainer_seen() {
+        Self::update_on_disk(|cfg| cfg.explainer_seen = true);
+    }
+
+    /// Read-modify-write one field of the on-disk config, preserving the rest.
+    fn update_on_disk(mutate: impl FnOnce(&mut Config)) {
         let Some(path) = Self::path() else { return };
         let mut cfg = std::fs::read_to_string(&path)
             .ok()
             .and_then(|t| toml::from_str::<Config>(&t).ok())
             .unwrap_or_default();
-        cfg.speedtest_provider = name.to_string();
+        mutate(&mut cfg);
         let _ = cfg.write_to(&path);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,12 +5,14 @@
 //! Input is read on a dedicated OS thread and delivered over a channel.
 
 mod app;
+mod baseline;
 mod collectors;
 mod config;
 mod platform;
 mod store;
 mod ui;
 mod util;
+mod verdict;
 
 use std::net::IpAddr;
 use std::sync::{Arc, Mutex};
@@ -19,10 +21,9 @@ use std::time::Duration;
 use anyhow::Result;
 use clap::Parser;
 use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
-use surge_ping::Client;
 use tokio::sync::{Notify, mpsc};
 
-use app::{AppState, InputMode, Panel, QualityView, SpeedStatus, SubPane, TargetStat};
+use app::{AppState, InputMode, Overlay, Panel, QualityView, SpeedStatus, SubPane, TargetStat};
 use config::Config;
 
 /// Handles shared with the input loop for issuing side effects.
@@ -30,7 +31,7 @@ struct Ctx {
     state: Arc<Mutex<AppState>>,
     speedtest_trigger: Arc<Notify>,
     netinfo_refresh: Arc<Notify>,
-    ping_client: Option<Arc<Client>>,
+    ping_clients: collectors::ping::Clients,
     cfg: Config,
 }
 
@@ -41,6 +42,30 @@ struct Cli {
     /// Run collectors briefly, print a text snapshot, then exit (no TUI).
     #[arg(long)]
     check: bool,
+
+    /// One-shot diagnosis: observe for ~20s, print the verdict with its
+    /// evidence and a paste-able report, then exit. Exit codes: 0 healthy,
+    /// 1 problems found, 3 could not measure.
+    #[arg(long)]
+    doctor: bool,
+
+    /// With --doctor: also run a speed test (observation takes ~45s).
+    #[arg(long)]
+    speedtest: bool,
+
+    /// With --doctor: print real SSIDs / IPs / MACs instead of redacting them.
+    /// The default output is safe to paste into a forum or ISP ticket.
+    #[arg(long)]
+    full: bool,
+
+    /// With --doctor: how many seconds to observe before reporting
+    /// (default 20, or 45 with --speedtest). Longer = better loss statistics.
+    #[arg(long, value_name = "SECS")]
+    observe: Option<u64>,
+
+    /// With --doctor: emit the report as JSON instead of text.
+    #[arg(long)]
+    json: bool,
 
     /// Disable the on-demand speed test.
     #[arg(long)]
@@ -125,47 +150,57 @@ async fn main() -> Result<()> {
     let speedtest_trigger = Arc::new(Notify::new()); // 's'
     let netinfo_refresh = Arc::new(Notify::new()); // 'r'
 
-    // Shared ICMP client so targets can be added at runtime.
+    // Shared per-family ICMP clients so targets can be added at runtime and v6
+    // addresses (common on carrier hotspots) are probed with the right socket.
     // Unprivileged datagram ICMP needs the kernel to allow it. macOS always
     // does; on Linux it depends on net.ipv4.ping_group_range, which several
     // distributions ship closed. Failing here disables every latency feature,
     // so the reason has to reach the user rather than a log nobody reads.
-    let ping_client = match Client::new(&surge_ping::Config::default()) {
-        Ok(c) => Some(Arc::new(c)),
-        Err(e) => {
-            tracing::error!("failed to create ICMP client: {e}");
-            state.lock().unwrap().icmp_error = Some(icmp_help(&e.to_string()));
-            None
-        }
-    };
+    let (ping_clients, v4_err) = collectors::ping::Clients::open();
+    if let Some(e) = v4_err {
+        tracing::error!("failed to create ICMP client: {e}");
+        state.lock().unwrap().icmp_error = Some(icmp_help(&e));
+    }
     {
         // Interrupt only for things that will visibly not work. A clean setup
         // starts straight into the dashboard.
         let mut s = state.lock().unwrap();
-        s.show_startup_notice =
-            !cli.check && (s.icmp_error.is_some() || !s.missing_tools.is_empty());
+        let headless = cli.check || cli.doctor;
+        if !headless && (s.icmp_error.is_some() || !s.missing_tools.is_empty()) {
+            s.overlay = Overlay::Startup;
+        }
+        // First run: explain what the tool answers and that it learns each
+        // network's normal. Setup problems keep precedence; the explainer then
+        // follows the startup notice's dismissal.
+        if !headless && !cfg.explainer_seen {
+            if s.overlay == Overlay::Startup {
+                s.explainer_pending = true;
+            } else {
+                s.overlay = Overlay::Explainer;
+            }
+        }
     }
     // Raised by the netinfo collector when the machine moves to a different
     // network, so path-dependent state can be rebuilt.
     let network_changed = Arc::new(Notify::new());
 
-    if let Some(client) = ping_client.clone() {
-        collectors::ping::spawn_all(state.clone(), client.clone(), cfg.clone());
+    if ping_clients.available() {
+        collectors::ping::spawn_all(state.clone(), ping_clients.clone(), cfg.clone());
         // Auto-discover the gateway + next hops, and the public IP, as targets.
         if !cli.check {
             tokio::spawn(collectors::discovery::run(
                 state.clone(),
-                client.clone(),
+                ping_clients.clone(),
                 cfg.clone(),
             ));
             tokio::spawn(collectors::discovery::public_ip(
                 state.clone(),
-                client.clone(),
+                ping_clients.clone(),
                 cfg.clone(),
             ));
             tokio::spawn(collectors::discovery::watch(
                 state.clone(),
-                client,
+                ping_clients.clone(),
                 cfg.clone(),
                 network_changed.clone(),
             ));
@@ -173,6 +208,12 @@ async fn main() -> Result<()> {
     }
 
     // Spawn collectors, each on its own cadence.
+    tokio::spawn(verdict::run(state.clone(), cfg.clone()));
+    tokio::spawn(collectors::http::run(
+        state.clone(),
+        cfg.clone(),
+        network_changed.clone(),
+    ));
     tokio::spawn(collectors::throughput::run(state.clone(), cfg.clone()));
     tokio::spawn(collectors::vitals::run(state.clone(), cfg.clone()));
     tokio::spawn(collectors::dns::run(state.clone(), cfg.clone()));
@@ -188,6 +229,11 @@ async fn main() -> Result<()> {
     ));
     tokio::spawn(collectors::signal::run(state.clone()));
     tokio::spawn(collectors::procbw::run(state.clone()));
+    tokio::spawn(collectors::web::run(state.clone()));
+    tokio::spawn(collectors::resolve::run(
+        state.clone(),
+        network_changed.clone(),
+    ));
     if !cli.no_speedtest {
         tokio::spawn(collectors::speedtest::run(
             state.clone(),
@@ -209,6 +255,50 @@ async fn main() -> Result<()> {
         }
         print_snapshot(&state.lock().unwrap());
         return Ok(());
+    }
+
+    // One-shot doctor: observe with everything running — including discovery
+    // and a hop monitor, which --check deliberately skips — judge once, print
+    // a paste-able report, and exit with a code scripts can branch on.
+    if cli.doctor {
+        // Let discovery find the gateway first, then watch the path to the
+        // first anchor so an ISP-segment fault can be localised headless.
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        if let Some(t) = cfg.targets.first().filter(|_| ping_clients.available()) {
+            collectors::hopmon::start(
+                state.clone(),
+                ping_clients.clone(),
+                cfg.clone(),
+                t.addr,
+                t.label.clone(),
+            );
+        }
+        // 2s of discovery already elapsed; the rest is the observation window.
+        let speedtest_wanted = cli.speedtest && !cli.no_speedtest;
+        let observe = cli
+            .observe
+            .unwrap_or(if speedtest_wanted { 45 } else { 20 })
+            .clamp(5, 600)
+            .saturating_sub(2);
+        if speedtest_wanted {
+            tokio::time::sleep(Duration::from_secs(3)).await;
+            speedtest_trigger.notify_one();
+            tokio::time::sleep(Duration::from_secs(observe.saturating_sub(3).max(1))).await;
+        } else {
+            tokio::time::sleep(Duration::from_secs(observe)).await;
+        }
+        let (report, code) = {
+            let s = state.lock().unwrap();
+            if cli.json {
+                doctor_json(&s, cli.full)
+            } else {
+                doctor_report(&s, cli.full)
+            }
+        };
+        print!("{report}");
+        use std::io::Write as _;
+        let _ = std::io::stdout().flush();
+        std::process::exit(code);
     }
 
     // Read terminal input on a blocking OS thread → async channel.
@@ -234,7 +324,7 @@ async fn main() -> Result<()> {
         state,
         speedtest_trigger,
         netinfo_refresh,
-        ping_client,
+        ping_clients,
         cfg,
     };
     let result = run_ui(&mut terminal, &ctx, rx).await;
@@ -275,20 +365,7 @@ async fn run_ui(
 /// numbers beside it look wrong.
 fn reset_panel(s: &mut AppState) {
     match s.focus {
-        Panel::Quality => {
-            for t in &mut s.targets {
-                t.reset();
-            }
-            // The path monitor's hops carry their own statistics and charts.
-            if let Some(m) = s.hop_monitor.as_mut() {
-                for h in &mut m.hops {
-                    if let Some(stat) = h.stat.as_mut() {
-                        stat.reset();
-                    }
-                }
-            }
-            s.traceroute = None;
-        }
+        Panel::Quality => s.reset_quality_stats(),
         Panel::Bandwidth => {
             s.throughput.down_hist.data.clear();
             s.throughput.up_hist.data.clear();
@@ -374,6 +451,14 @@ enum Side {
     Traceroute(IpAddr, String),
     HopMonitor(IpAddr, String),
     SaveProvider(String),
+    /// Persist the user's name for the current network's baseline.
+    NameNetwork {
+        key: String,
+        label: String,
+        name: String,
+    },
+    /// Read every stored baseline off disk for the locations overlay.
+    LoadLocations,
 }
 
 /// Remove the selected target, pulling the dependent cursors back into range.
@@ -459,9 +544,26 @@ fn handle_key(ctx: &Ctx, key: KeyEvent) {
         s.notice = None; // any key clears a transient notice
 
         // The setup modal is dismissed by any key, and swallows it so a stray
-        // press does not also trigger an action behind the modal.
-        if s.show_startup_notice && s.input_mode == InputMode::Normal {
-            s.show_startup_notice = false;
+        // press does not also trigger an action behind the modal. The first-run
+        // explainer, when pending, takes the slot the dismissal frees.
+        if s.overlay == Overlay::Startup && s.input_mode == InputMode::Normal {
+            s.overlay = if s.explainer_pending {
+                s.explainer_pending = false;
+                Overlay::Explainer
+            } else {
+                Overlay::None
+            };
+            if !matches!(key.code, KeyCode::Char('q')) && !(ctrl && key.code == KeyCode::Char('c'))
+            {
+                return;
+            }
+        }
+
+        // The explainer is also any-key-dismissed, and is shown exactly once:
+        // dismissal is persisted (off the key path) so it never reappears.
+        if s.overlay == Overlay::Explainer && s.input_mode == InputMode::Normal {
+            s.overlay = Overlay::None;
+            tokio::task::spawn_blocking(Config::persist_explainer_seen);
             if !matches!(key.code, KeyCode::Char('q')) && !(ctrl && key.code == KeyCode::Char('c'))
             {
                 return;
@@ -490,11 +592,101 @@ fn handle_key(ctx: &Ctx, key: KeyEvent) {
                 _ => {}
             },
 
-            // --- help overlay: swallow most keys ---
-            InputMode::Normal if s.show_help => match key.code {
+            // --- modal text entry: naming the current network ---
+            InputMode::NameNetwork => match key.code {
+                KeyCode::Enter => {
+                    let name = s.input_buffer.trim().to_string();
+                    s.input_mode = InputMode::Normal;
+                    s.input_buffer.clear();
+                    if let (Some(key), Some(b)) = (s.baseline_key.clone(), s.baseline.as_mut()) {
+                        // Update the in-memory copy immediately for display;
+                        // the file write happens off the key path.
+                        b.name = if name.is_empty() {
+                            None
+                        } else {
+                            Some(name.clone())
+                        };
+                        let label = b.label.clone();
+                        side = Side::NameNetwork { key, label, name };
+                    }
+                }
+                KeyCode::Esc => {
+                    s.input_mode = InputMode::Normal;
+                    s.input_buffer.clear();
+                }
+                KeyCode::Backspace => {
+                    s.input_buffer.pop();
+                }
+                KeyCode::Char(c) if s.input_buffer.len() < 40 => s.input_buffer.push(c),
+                _ => {}
+            },
+
+            // --- help / triage / events overlays: swallow most keys. Each
+            // overlay's own key toggles it and switches from the others, so
+            // flipping between them never needs an Esc in between.
+            InputMode::Normal if s.overlay != Overlay::None => match key.code {
                 KeyCode::Char('q') => s.should_quit = true,
                 KeyCode::Char('c') if ctrl => s.should_quit = true,
-                KeyCode::Esc | KeyCode::Char('?') => s.show_help = false,
+                KeyCode::Esc => s.overlay = Overlay::None,
+                KeyCode::Char('?') => {
+                    s.overlay = if s.overlay == Overlay::Help {
+                        Overlay::None
+                    } else {
+                        Overlay::Help
+                    };
+                }
+                KeyCode::Char('y') => {
+                    s.overlay = if s.overlay == Overlay::Triage {
+                        Overlay::None
+                    } else {
+                        Overlay::Triage
+                    };
+                }
+                KeyCode::Char('e') => {
+                    s.overlay = if s.overlay == Overlay::Events {
+                        Overlay::None
+                    } else {
+                        s.events_scroll = 0;
+                        Overlay::Events
+                    };
+                }
+                KeyCode::Char('L') => {
+                    s.overlay = if s.overlay == Overlay::Locations {
+                        Overlay::None
+                    } else {
+                        s.locations = None;
+                        s.locations_sel = 0;
+                        side = Side::LoadLocations;
+                        Overlay::Locations
+                    };
+                }
+                // Scroll the timeline; clamped so it can't run past the oldest.
+                KeyCode::Up | KeyCode::Char('k') if s.overlay == Overlay::Events => {
+                    s.events_scroll =
+                        (s.events_scroll + 1).min(s.events.len().saturating_sub(1));
+                }
+                KeyCode::Down | KeyCode::Char('j') if s.overlay == Overlay::Events => {
+                    s.events_scroll = s.events_scroll.saturating_sub(1);
+                }
+                KeyCode::PageUp if s.overlay == Overlay::Events => {
+                    s.events_scroll =
+                        (s.events_scroll + 10).min(s.events.len().saturating_sub(1));
+                }
+                KeyCode::PageDown if s.overlay == Overlay::Events => {
+                    s.events_scroll = s.events_scroll.saturating_sub(10);
+                }
+                // Scroll the locations list.
+                KeyCode::Up | KeyCode::Char('k') if s.overlay == Overlay::Locations => {
+                    s.locations_sel = s.locations_sel.saturating_sub(1);
+                }
+                KeyCode::Down | KeyCode::Char('j') if s.overlay == Overlay::Locations => {
+                    let last = s
+                        .locations
+                        .as_ref()
+                        .map(|l| l.len().saturating_sub(1))
+                        .unwrap_or(0);
+                    s.locations_sel = (s.locations_sel + 1).min(last);
+                }
                 _ => {}
             },
 
@@ -511,7 +703,14 @@ fn handle_key(ctx: &Ctx, key: KeyEvent) {
                         s.quality_view = QualityView::Graph;
                     }
                 }
-                KeyCode::Char('?') => s.show_help = true,
+                KeyCode::Char('?') => s.overlay = Overlay::Help,
+                // 'y' answers "why does the verdict say that": the triage ladder.
+                KeyCode::Char('y') => s.overlay = Overlay::Triage,
+                // 'e' opens the session timeline.
+                KeyCode::Char('e') => {
+                    s.events_scroll = 0;
+                    s.overlay = Overlay::Events;
+                }
                 KeyCode::Tab => s.focus = next_panel(s.focus),
                 KeyCode::BackTab => s.focus = prev_panel(s.focus),
                 KeyCode::Char('f') => s.fullscreen = !s.fullscreen,
@@ -526,6 +725,23 @@ fn handle_key(ctx: &Ctx, key: KeyEvent) {
                 KeyCode::Char('l') => s.logging_requested = !s.logging_requested,
                 // Shift+R resets the focused panel's accumulated data.
                 KeyCode::Char('R') => reset_panel(&mut s),
+                // Shift+L lists every stored network location (Network panel).
+                KeyCode::Char('L') if s.focus == Panel::NetInfo => {
+                    s.locations = None;
+                    s.locations_sel = 0;
+                    s.overlay = Overlay::Locations;
+                    side = Side::LoadLocations;
+                }
+                // Shift+N names the current network's baseline ("Home"…).
+                // Pre-filled with the existing name so editing beats retyping.
+                KeyCode::Char('N') if s.baseline_key.is_some() => {
+                    s.input_buffer = s
+                        .baseline
+                        .as_ref()
+                        .and_then(|b| b.name.clone())
+                        .unwrap_or_default();
+                    s.input_mode = InputMode::NameNetwork;
+                }
                 // 'v' cycles the speed-test provider (Bandwidth panel) + persists.
                 KeyCode::Char('v') if s.focus == Panel::Bandwidth => {
                     let n = s.speedtest_provider_names.len();
@@ -634,6 +850,10 @@ fn handle_key(ctx: &Ctx, key: KeyEvent) {
                         let (addr, label) = (t.addr, t.label.clone());
                         let already = s.hop_monitor.as_ref().is_some_and(|m| m.dest == addr);
                         s.quality_view = QualityView::HopMonitor;
+                        // The web strip follows the monitored target too — the
+                        // point of monitoring one is that it's the one you care
+                        // about right now.
+                        s.graph_target = s.selected;
                         if !already {
                             side = Side::HopMonitor(addr, label);
                         }
@@ -656,40 +876,79 @@ fn handle_key(ctx: &Ctx, key: KeyEvent) {
         Side::None => {}
         Side::Speedtest => ctx.speedtest_trigger.notify_one(),
         Side::Refresh => ctx.netinfo_refresh.notify_one(),
-        Side::AddTarget(input) => match ctx.ping_client.clone() {
-            Some(client) => {
+        Side::AddTarget(input) => {
+            if ctx.ping_clients.available() {
                 tokio::spawn(add_target(
                     ctx.state.clone(),
-                    client,
+                    ctx.ping_clients.clone(),
                     ctx.cfg.clone(),
                     input,
                 ));
+            } else {
+                ctx.state.lock().unwrap().notice = Some("ICMP unavailable".to_string());
             }
-            None => ctx.state.lock().unwrap().notice = Some("ICMP unavailable".to_string()),
-        },
+        }
         Side::Traceroute(addr, label) => {
             collectors::traceroute::start(ctx.state.clone(), addr, label);
         }
-        Side::HopMonitor(addr, label) => match ctx.ping_client.clone() {
-            Some(client) => {
-                collectors::hopmon::start(ctx.state.clone(), client, ctx.cfg.clone(), addr, label)
+        Side::HopMonitor(addr, label) => {
+            if ctx.ping_clients.available() {
+                collectors::hopmon::start(
+                    ctx.state.clone(),
+                    ctx.ping_clients.clone(),
+                    ctx.cfg.clone(),
+                    addr,
+                    label,
+                );
+            } else {
+                ctx.state.lock().unwrap().notice = Some("ICMP unavailable".to_string());
             }
-            None => ctx.state.lock().unwrap().notice = Some("ICMP unavailable".to_string()),
-        },
+        }
         Side::SaveProvider(name) => {
             tokio::task::spawn_blocking(move || config::Config::persist_provider(&name));
+        }
+        Side::NameNetwork { key, label, name } => {
+            tokio::task::spawn_blocking(move || baseline::name_network(&key, &label, &name));
+        }
+        Side::LoadLocations => {
+            let state = ctx.state.clone();
+            tokio::spawn(async move {
+                let mut all: Vec<(String, baseline::Baseline)> =
+                    tokio::task::spawn_blocking(baseline::load)
+                        .await
+                        .unwrap_or_default()
+                        .into_iter()
+                        .collect();
+                // Most-established first, named before unnamed on ties.
+                all.sort_by(|a, b| {
+                    b.1.samples
+                        .cmp(&a.1.samples)
+                        .then_with(|| a.1.display_name().to_lowercase().cmp(
+                            &b.1.display_name().to_lowercase(),
+                        ))
+                });
+                state.lock().unwrap().locations = Some(all);
+            });
         }
     }
 }
 
 /// Resolve a user-entered IP or DNS name, append it as a target, and start
 /// pinging it. Reports failures via the transient `notice`.
-async fn add_target(state: Arc<Mutex<AppState>>, client: Arc<Client>, cfg: Config, input: String) {
-    let addr: IpAddr = match input.parse() {
-        Ok(ip) => ip,
+async fn add_target(
+    state: Arc<Mutex<AppState>>,
+    clients: collectors::ping::Clients,
+    cfg: Config,
+    input: String,
+) {
+    // Remember whether this was a *name*: names get re-resolved when the
+    // network changes (CDNs answer per location) and probed over HTTPS with
+    // proper SNI, neither of which a bare IP can offer.
+    let (addr, hostname): (IpAddr, Option<String>) = match input.parse() {
+        Ok(ip) => (ip, None),
         Err(_) => match tokio::net::lookup_host((input.as_str(), 0)).await {
             Ok(mut addrs) => match addrs.next() {
-                Some(sa) => sa.ip(),
+                Some(sa) => (sa.ip(), Some(input.clone())),
                 None => {
                     state.lock().unwrap().notice = Some(format!("no address for {input}"));
                     return;
@@ -705,19 +964,33 @@ async fn add_target(state: Arc<Mutex<AppState>>, client: Arc<Client>, cfg: Confi
     let id = {
         let mut s = state.lock().unwrap();
         let idx = s.targets.len();
-        let target = TargetStat::new(input.clone(), addr);
+        let mut target = TargetStat::new(input.clone(), addr);
+        target.hostname = hostname;
         let id = target.id;
         s.targets.push(target);
         s.selected = idx;
         s.graph_target = idx;
         id
     };
-    collectors::ping::spawn_for(state, client, cfg, id, addr);
+    collectors::ping::spawn_for(state, clients, cfg, id, addr);
 }
 
 /// Text dump of the current state for `--check` / debugging.
 fn print_snapshot(s: &AppState) {
-    println!("== octomon --check ==");
+    print!("{}", snapshot_text(s));
+}
+
+/// The measurement report as a string, so `--doctor` can embed and redact it.
+#[allow(unused_macros)]
+fn snapshot_text(s: &AppState) -> String {
+    let mut out = String::new();
+    // Shadow `println!` so the many formatting call sites below write into
+    // `out` unchanged instead of straight to stdout.
+    macro_rules! println {
+        () => { out.push('\n') };
+        ($($t:tt)*) => {{ use std::fmt::Write as _; let _ = writeln!(out, $($t)*); }};
+    }
+    println!("== MEASUREMENTS ==");
     let n = s.window_samples();
     println!("\n[Connection Quality]  (window {})", s.window_label());
     let ms = |v: Option<f64>| v.map(|x| format!("{x:.1}")).unwrap_or_else(|| "—".into());
@@ -909,6 +1182,234 @@ fn print_snapshot(s: &AppState) {
         e.error_pct(),
         e.rx_packets_per_sec + e.tx_packets_per_sec
     );
+    out
+}
+
+/// The `--doctor` report: verdict first, then this network's learned normal,
+/// the raw measurements, and the session's events — with identifying details
+/// (SSID, IPs, MACs) redacted unless `--full`, so the default output is safe
+/// to paste into a forum or an ISP ticket.
+fn doctor_report(s: &AppState, full: bool) -> (String, i32) {
+    use std::fmt::Write as _;
+    let triage = verdict::evaluate(s);
+    let insufficient = verdict::insufficient_reason(s);
+
+    let mut out = String::new();
+    let _ = writeln!(
+        out,
+        "octomon v{} · doctor · {} · {}",
+        env!("CARGO_PKG_VERSION"),
+        chrono::Local::now().format("%Y-%m-%d %H:%M"),
+        s.netinfo.medium.label(),
+    );
+    if let Some(err) = &s.icmp_error {
+        let _ = writeln!(out, "\n{err}");
+    }
+    let _ = writeln!(out);
+    out.push_str(&verdict::render_text(&triage, insufficient.as_deref()));
+
+    // The location always prints, named or not — knowing WHERE the report was
+    // taken (and how established its baseline is) is part of the diagnosis.
+    if let Some(b) = s.baseline.as_ref() {
+        let _ = writeln!(out, "\n== NORMAL AT \"{}\" ==", b.display_name());
+        let ms = |v: Option<f64>| v.map(|x| format!("~{x:.0}ms")).unwrap_or_else(|| "—".into());
+        let _ = writeln!(
+            out,
+            "  gateway {} · internet {} · DNS {}{}{}",
+            ms(b.gateway_ms),
+            ms(b.anchor_ms),
+            ms(b.dns_ms),
+            b.rssi_dbm
+                .map(|r| format!(" · rssi ~{r:.0} dBm"))
+                .unwrap_or_default(),
+            match (b.down_mbps, b.up_mbps) {
+                (Some(d), Some(u)) => format!(" · speed ~{d:.0}↓/{u:.0}↑ Mbps"),
+                _ => String::new(),
+            }
+        );
+        let _ = writeln!(
+            out,
+            "  ({} healthy minutes learned{})",
+            b.samples,
+            if b.established() {
+                ""
+            } else {
+                " — still learning, comparisons not yet trusted"
+            }
+        );
+    }
+
+    let _ = writeln!(out);
+    out.push_str(&snapshot_text(s));
+
+    if !s.events.is_empty() {
+        let _ = writeln!(out, "\n== EVENTS (last {}) ==", s.events.len().min(20));
+        for e in s.events.iter().rev().take(20).collect::<Vec<_>>().iter().rev() {
+            let _ = writeln!(out, "  {}  {:<9} {}", e.when(), e.category.label(), e.message);
+        }
+    }
+
+    let code = verdict::exit_code(&triage, insufficient.is_some());
+    let out = if full { out } else { redact_report(out, s) };
+    (out, code)
+}
+
+/// The `--doctor --json` report: same content and redaction rules as the text
+/// report, shaped for machines. Redaction runs on the serialized string, so
+/// the two formats can never disagree about what is hidden.
+fn doctor_json(s: &AppState, full: bool) -> (String, i32) {
+    use serde_json::json;
+    let triage = verdict::evaluate(s);
+    let insufficient = verdict::insufficient_reason(s);
+    let code = verdict::exit_code(&triage, insufficient.is_some());
+    let n = s.window_samples();
+
+    let family = |f: &app::FamilyProbe| match f {
+        app::FamilyProbe::NotRun => json!({"status": "not-run"}),
+        app::FamilyProbe::NotApplicable => json!({"status": "not-applicable"}),
+        app::FamilyProbe::Ok(ms) => json!({"status": "ok", "rtt_ms": ms}),
+        app::FamilyProbe::Captive(loc) => json!({"status": "captive", "redirect": loc}),
+        app::FamilyProbe::Fail(r) => json!({"status": "fail", "reason": r}),
+    };
+
+    let doc = json!({
+        "octomon_version": env!("CARGO_PKG_VERSION"),
+        "at": chrono::Local::now().to_rfc3339(),
+        "medium": s.netinfo.medium.label(),
+        "exit_code": code,
+        "status": match (&insufficient, triage.findings.iter().any(|f| f.severity >= verdict::Severity::Degraded)) {
+            (Some(_), _) => "insufficient",
+            (None, true) => "problems",
+            (None, false) => "healthy",
+        },
+        "insufficient_reason": insufficient,
+        "analysis": {
+            "ladder": triage.rungs.iter().map(|r| json!({
+                "area": r.area.label(),
+                "status": r.status.label(),
+                "detail": r.detail,
+            })).collect::<Vec<_>>(),
+            "findings": triage.findings.iter().map(|f| json!({
+                "cause": f.cause.label(),
+                "severity": f.severity.label(),
+                "confidence": f.confidence.word(),
+                "summary": f.summary,
+                "evidence": f.evidence,
+            })).collect::<Vec<_>>(),
+        },
+        "location": s.baseline.as_ref().map(|b| json!({
+            "name": b.name,
+            "label": b.label,
+            "healthy_minutes": b.samples,
+            "established": b.established(),
+            "normal": {
+                "gateway_ms": b.gateway_ms,
+                "internet_ms": b.anchor_ms,
+                "dns_ms": b.dns_ms,
+                "rssi_dbm": b.rssi_dbm,
+                "down_mbps": b.down_mbps,
+                "up_mbps": b.up_mbps,
+            },
+        })),
+        "targets": s.targets.iter().map(|t| {
+            let st = t.stats(n);
+            json!({
+                "label": t.label,
+                "addr": t.addr.to_string(),
+                "hostname": t.hostname,
+                "discovered": t.discovered,
+                "last_ms": t.last_rtt_ms,
+                "mean_ms": st.mean,
+                "p95_ms": st.p95,
+                "jitter_ms": t.jitter_ms,
+                "loss_pct": t.loss_pct(),
+                "sent": t.sent,
+                "recv": t.recv,
+                "web_status": t.web.status.label(),
+                "web_ttfb_ms": t.web.last_ttfb_ms,
+            })
+        }).collect::<Vec<_>>(),
+        "dns": s.dns.iter().map(|p| json!({
+            "server": p.server.to_string(),
+            "last_ms": p.last_ms,
+            "mean_ms": p.mean_ms(),
+            "fail_pct": p.fail_pct(),
+        })).collect::<Vec<_>>(),
+        "http": {
+            "provider": s.http.provider,
+            "v4": family(&s.http.v4),
+            "v6": family(&s.http.v6),
+            "note": s.http.note,
+        },
+        "machine": {
+            "cpu_pct": s.vitals.cpu_pct,
+            "mem_pressure_pct": s.vitals.mem_pressure_pct,
+            "throttled": s.vitals.throttled,
+            "link_error_pct": s.link_errors.error_pct(),
+        },
+        "events": s.events.iter().rev().take(20).map(|e| json!({
+            "at": e.at,
+            "category": e.category.label(),
+            "severity": e.severity.label(),
+            "message": e.message,
+        })).collect::<Vec<_>>(),
+    });
+
+    let text = serde_json::to_string_pretty(&doc).unwrap_or_else(|_| "{}".to_string());
+    let text = if full { text } else { redact_report(text, s) };
+    (text + "\n", code)
+}
+
+/// Best-effort scrub of identifying values from a report. Deliberately
+/// list-based (this machine's actual SSID/IPs/MACs) rather than pattern-based:
+/// ISP-side hop addresses are the useful part of a ticket and must survive.
+fn redact_report(text: String, s: &AppState) -> String {
+    let mut subs: Vec<(String, &'static str)> = Vec::new();
+    let mut push = |v: &str, mask: &'static str| {
+        if !v.is_empty() && v != "-" {
+            subs.push((v.to_string(), mask));
+        }
+    };
+    if let Some(w) = &s.netinfo.wifi
+        && !w.ssid.contains("redacted")
+    {
+        push(&w.ssid, "<ssid>");
+    }
+    for t in s.targets.iter().filter(|t| t.discovered) {
+        if t.label.contains("public") {
+            push(&t.addr.to_string(), "<public-ip>");
+        }
+    }
+    for a in s.netinfo.ipv4.iter().chain(s.netinfo.ipv6.iter()) {
+        push(a, "<ip>");
+        if let Some(bare) = a.split('/').next() {
+            push(bare, "<ip>");
+        }
+    }
+    push(&s.netinfo.gateway_ip, "<gateway>");
+    push(&s.netinfo.mac, "<mac>");
+    push(&s.netinfo.gateway_mac, "<mac>");
+    // LAN-side resolvers (a Pi-hole, the router) are private addresses too;
+    // public resolvers are not ours to hide.
+    for d in &s.netinfo.dns {
+        if d.parse::<std::net::Ipv4Addr>().is_ok_and(|ip| ip.is_private()) {
+            push(d, "<dns>");
+        }
+    }
+    // The auto label of an unnamed baseline is the SSID or the gateway IP; a
+    // user-chosen name ("Home") was picked to be shareable and stays. Pushed
+    // last so the more specific masks above win a same-string tie.
+    if let Some(b) = &s.baseline
+        && b.name.is_none()
+    {
+        push(&b.label, "<network>");
+    }
+
+    // Longest first (stable, so earlier = more specific on ties), so
+    // "192.168.1.100" is consumed before "192.168.1.1" can corrupt it.
+    subs.sort_by_key(|(v, _)| std::cmp::Reverse(v.len()));
+    subs.into_iter()
+        .fold(text, |acc, (v, mask)| acc.replace(&v, mask))
 }
 
 fn next_panel(p: Panel) -> Panel {
@@ -1096,6 +1597,79 @@ mod tests {
             s.has_sub_pane(),
             "an empty history is still a pane worth focusing"
         );
+    }
+
+    /// The default doctor report must be safe to paste into a public ticket:
+    /// the machine's own identifiers gone, ISP-side detail kept.
+    #[test]
+    fn doctor_report_redacts_by_default_and_not_with_full() {
+        let mut s = AppState::new(vec![TargetStat::new(
+            "Cloudflare".into(),
+            IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)),
+        )]);
+        for _ in 0..20 {
+            s.targets[0].record_reply(12.0);
+        }
+        let mut public = TargetStat::new("public IP".into(), IpAddr::V4(Ipv4Addr::new(203, 0, 113, 77)));
+        public.discovered = true;
+        s.targets.push(public);
+        s.netinfo.iface = "en0".into();
+        s.netinfo.medium = crate::app::LinkMedium::WiFi;
+        s.netinfo.ipv4 = vec!["192.168.1.100/24".into()];
+        s.netinfo.gateway_ip = "192.168.1.1".into();
+        s.netinfo.mac = "aa:bb:cc:11:22:33".into();
+        s.netinfo.gateway_mac = "de:ad:be:ef:00:01".into();
+        s.netinfo.wifi = Some(crate::app::WifiInfo {
+            ssid: "MySecretWifi".into(),
+            ..Default::default()
+        });
+        // A LAN resolver (Pi-hole) is private; Cloudflare's resolver is not.
+        s.netinfo.dns = vec!["192.168.1.4".into(), "1.1.1.1".into()];
+
+        let (out, _code) = doctor_report(&s, false);
+        for secret in [
+            "MySecretWifi",
+            "192.168.1.100",
+            "192.168.1.1",
+            "192.168.1.4",
+            "aa:bb:cc:11:22:33",
+            "de:ad:be:ef:00:01",
+            "203.0.113.77",
+        ] {
+            assert!(!out.contains(secret), "leaked {secret:?}");
+        }
+        assert!(out.contains("<ssid>"));
+        assert!(out.contains("<gateway>"));
+        assert!(out.contains("<public-ip>"));
+        assert!(out.contains("<dns>"));
+        // The anchor's address is not ours to hide — it's the useful part.
+        assert!(out.contains("1.1.1.1"));
+        assert!(out.contains("== ANALYSIS =="));
+
+        let (full, _code) = doctor_report(&s, true);
+        assert!(full.contains("MySecretWifi"));
+        assert!(full.contains("192.168.1.1"));
+    }
+
+    /// A user-chosen location name was picked to be shareable; the automatic
+    /// label (the SSID) was not.
+    #[test]
+    fn doctor_keeps_chosen_names_but_hides_auto_labels() {
+        let mut s = AppState::new(vec![]);
+        s.baseline = Some(crate::baseline::Baseline {
+            label: "MySecretWifi".into(),
+            name: Some("Home".into()),
+            samples: 10,
+            gateway_ms: Some(9.0),
+            ..Default::default()
+        });
+        let (out, _) = doctor_report(&s, false);
+        assert!(out.contains("NORMAL AT \"Home\""));
+
+        s.baseline.as_mut().unwrap().name = None;
+        let (out, _) = doctor_report(&s, false);
+        assert!(!out.contains("MySecretWifi"));
+        assert!(out.contains("<network>"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -662,15 +662,13 @@ fn handle_key(ctx: &Ctx, key: KeyEvent) {
                 }
                 // Scroll the timeline; clamped so it can't run past the oldest.
                 KeyCode::Up | KeyCode::Char('k') if s.overlay == Overlay::Events => {
-                    s.events_scroll =
-                        (s.events_scroll + 1).min(s.events.len().saturating_sub(1));
+                    s.events_scroll = (s.events_scroll + 1).min(s.events.len().saturating_sub(1));
                 }
                 KeyCode::Down | KeyCode::Char('j') if s.overlay == Overlay::Events => {
                     s.events_scroll = s.events_scroll.saturating_sub(1);
                 }
                 KeyCode::PageUp if s.overlay == Overlay::Events => {
-                    s.events_scroll =
-                        (s.events_scroll + 10).min(s.events.len().saturating_sub(1));
+                    s.events_scroll = (s.events_scroll + 10).min(s.events.len().saturating_sub(1));
                 }
                 KeyCode::PageDown if s.overlay == Overlay::Events => {
                     s.events_scroll = s.events_scroll.saturating_sub(10);
@@ -921,11 +919,11 @@ fn handle_key(ctx: &Ctx, key: KeyEvent) {
                         .collect();
                 // Most-established first, named before unnamed on ties.
                 all.sort_by(|a, b| {
-                    b.1.samples
-                        .cmp(&a.1.samples)
-                        .then_with(|| a.1.display_name().to_lowercase().cmp(
-                            &b.1.display_name().to_lowercase(),
-                        ))
+                    b.1.samples.cmp(&a.1.samples).then_with(|| {
+                        a.1.display_name()
+                            .to_lowercase()
+                            .cmp(&b.1.display_name().to_lowercase())
+                    })
                 });
                 state.lock().unwrap().locations = Some(all);
             });
@@ -1212,7 +1210,10 @@ fn doctor_report(s: &AppState, full: bool) -> (String, i32) {
     // taken (and how established its baseline is) is part of the diagnosis.
     if let Some(b) = s.baseline.as_ref() {
         let _ = writeln!(out, "\n== NORMAL AT \"{}\" ==", b.display_name());
-        let ms = |v: Option<f64>| v.map(|x| format!("~{x:.0}ms")).unwrap_or_else(|| "—".into());
+        let ms = |v: Option<f64>| {
+            v.map(|x| format!("~{x:.0}ms"))
+                .unwrap_or_else(|| "—".into())
+        };
         let _ = writeln!(
             out,
             "  gateway {} · internet {} · DNS {}{}{}",
@@ -1244,8 +1245,22 @@ fn doctor_report(s: &AppState, full: bool) -> (String, i32) {
 
     if !s.events.is_empty() {
         let _ = writeln!(out, "\n== EVENTS (last {}) ==", s.events.len().min(20));
-        for e in s.events.iter().rev().take(20).collect::<Vec<_>>().iter().rev() {
-            let _ = writeln!(out, "  {}  {:<9} {}", e.when(), e.category.label(), e.message);
+        for e in s
+            .events
+            .iter()
+            .rev()
+            .take(20)
+            .collect::<Vec<_>>()
+            .iter()
+            .rev()
+        {
+            let _ = writeln!(
+                out,
+                "  {}  {:<9} {}",
+                e.when(),
+                e.category.label(),
+                e.message
+            );
         }
     }
 
@@ -1392,7 +1407,9 @@ fn redact_report(text: String, s: &AppState) -> String {
     // LAN-side resolvers (a Pi-hole, the router) are private addresses too;
     // public resolvers are not ours to hide.
     for d in &s.netinfo.dns {
-        if d.parse::<std::net::Ipv4Addr>().is_ok_and(|ip| ip.is_private()) {
+        if d.parse::<std::net::Ipv4Addr>()
+            .is_ok_and(|ip| ip.is_private())
+        {
             push(d, "<dns>");
         }
     }
@@ -1610,7 +1627,10 @@ mod tests {
         for _ in 0..20 {
             s.targets[0].record_reply(12.0);
         }
-        let mut public = TargetStat::new("public IP".into(), IpAddr::V4(Ipv4Addr::new(203, 0, 113, 77)));
+        let mut public = TargetStat::new(
+            "public IP".into(),
+            IpAddr::V4(Ipv4Addr::new(203, 0, 113, 77)),
+        );
         public.discovered = true;
         s.targets.push(public);
         s.netinfo.iface = "en0".into();

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -6,8 +6,8 @@ use ratatui::prelude::*;
 use ratatui::style::Modifier;
 use ratatui::symbols::Marker;
 use ratatui::widgets::{
-    Axis, Block, Cell, Chart, Clear, Dataset, Gauge, GraphType, LineGauge, Padding, Paragraph,
-    Row, Sparkline, SparklineBar, Table, Wrap,
+    Axis, Block, Cell, Chart, Clear, Dataset, Gauge, GraphType, LineGauge, Padding, Paragraph, Row,
+    Sparkline, SparklineBar, Table, Wrap,
 };
 
 use crate::app::{
@@ -92,7 +92,10 @@ fn locations_overlay(f: &mut Frame, s: &AppState, area: Rect) {
             // fully visible the offset stays pinned at zero.
             let max_first = all.len().saturating_sub(visible.max(1));
             let first = s.locations_sel.min(max_first);
-            let ms = |v: Option<f64>| v.map(|x| format!("~{x:.0}ms")).unwrap_or_else(|| "—".into());
+            let ms = |v: Option<f64>| {
+                v.map(|x| format!("~{x:.0}ms"))
+                    .unwrap_or_else(|| "—".into())
+            };
             for (key, b) in all.iter().skip(first).take(visible.max(1)) {
                 let current = s.baseline_key.as_deref() == Some(key.as_str());
                 let mut name_row = vec![Span::styled(
@@ -163,7 +166,12 @@ fn explainer_overlay(f: &mut Frame, area: Rect) {
             Span::styled(t.to_string(), Style::new().fg(Color::Gray)),
         ])
     };
-    let dim = |t: &str| Line::from(Span::styled(format!("   {t}"), Style::new().fg(Color::DarkGray)));
+    let dim = |t: &str| {
+        Line::from(Span::styled(
+            format!("   {t}"),
+            Style::new().fg(Color::DarkGray),
+        ))
+    };
 
     let lines = vec![
         head("this tool helps you diagnose internet connectivity issues:"),
@@ -524,9 +532,8 @@ fn footer(f: &mut Frame, s: &AppState, area: Rect) {
     };
     match rec {
         Some(r) => {
-            let cols =
-                Layout::horizontal([Constraint::Min(0), Constraint::Length(r.len() as u16)])
-                    .split(area);
+            let cols = Layout::horizontal([Constraint::Min(0), Constraint::Length(r.len() as u16)])
+                .split(area);
             f.render_widget(Paragraph::new(line), cols[0]);
             f.render_widget(
                 Paragraph::new(Span::styled(r, Style::new().fg(Color::Red)))
@@ -843,7 +850,10 @@ fn quality_panel(f: &mut Frame, s: &AppState, area: Rect) {
     }
     if let Some(t) = s.targets.get(s.graph_target) {
         let st = t.stats(n);
-        title.push_str(&format!(" · {}: jit {:.1} · sd {:.1}", t.label, t.jitter_ms, st.stddev));
+        title.push_str(&format!(
+            " · {}: jit {:.1} · sd {:.1}",
+            t.label, t.jitter_ms, st.stddev
+        ));
         if let Some(bloat) = t.bufferbloat_ms(n) {
             let (grade, _) = bufferbloat_grade(bloat);
             title.push_str(&format!(" · bloat +{bloat:.0}ms {grade}"));
@@ -921,7 +931,9 @@ fn web_graph(f: &mut Frame, s: &AppState, area: Rect) {
             "TCP filtered — ping answers, web dropped".to_string(),
             Style::new().fg(Color::Yellow),
         ),
-        WebStatus::Unknown => Span::styled("checking…".to_string(), Style::new().fg(Color::DarkGray)),
+        WebStatus::Unknown => {
+            Span::styled("checking…".to_string(), Style::new().fg(Color::DarkGray))
+        }
     };
     f.render_widget(Paragraph::new(Line::from(vec![head, detail])), rows[0]);
 
@@ -929,7 +941,11 @@ fn web_graph(f: &mut Frame, s: &AppState, area: Rect) {
     if !data.is_empty() {
         f.render_widget(
             Sparkline::default()
-                .data(data.iter().map(|v| SparklineBar::from(*v)).collect::<Vec<_>>())
+                .data(
+                    data.iter()
+                        .map(|v| SparklineBar::from(*v))
+                        .collect::<Vec<_>>(),
+                )
                 .style(Style::new().fg(SERIES_COLOR)),
             rows[1],
         );
@@ -2343,7 +2359,10 @@ fn http_line(s: &AppState) -> Option<Line<'static>> {
     let span = |f: &FP, name: &str| match f {
         FP::NotRun => Span::styled(format!("{name} …"), Style::new().fg(Color::DarkGray)),
         FP::NotApplicable => Span::styled(format!("{name} n/a"), Style::new().fg(Color::DarkGray)),
-        FP::Ok(ms) => Span::styled(format!("{name} ok {ms:.0}ms"), Style::new().fg(Color::Green)),
+        FP::Ok(ms) => Span::styled(
+            format!("{name} ok {ms:.0}ms"),
+            Style::new().fg(Color::Green),
+        ),
         FP::Captive(_) => Span::styled(
             "CAPTIVE PORTAL".to_string(),
             Style::new().fg(Color::Red).bold(),
@@ -2960,10 +2979,8 @@ mod tests {
         s.verdict.current = Verdict::Healthy;
         assert!(draw(&s, 120, 24).contains("connection healthy"));
 
-        s.verdict.current = Verdict::Problems(vec![
-            finding(Severity::Down),
-            finding(Severity::Degraded),
-        ]);
+        s.verdict.current =
+            Verdict::Problems(vec![finding(Severity::Down), finding(Severity::Degraded)]);
         let out = draw(&s, 120, 24);
         assert!(out.contains("gateway unresponsive"));
         // Confidence wording stays in the [y] overlay, off the headline.
@@ -2989,9 +3006,10 @@ mod tests {
 
     #[test]
     fn triage_overlay_shows_the_whole_ladder_with_its_data() {
-        let mut s = AppState::new(vec![
-            crate::app::TargetStat::new("Cloudflare".into(), "1.1.1.1".parse().unwrap()),
-        ]);
+        let mut s = AppState::new(vec![crate::app::TargetStat::new(
+            "Cloudflare".into(),
+            "1.1.1.1".parse().unwrap(),
+        )]);
         for _ in 0..20 {
             s.targets[0].record_reply(12.0);
         }
@@ -3005,11 +3023,21 @@ mod tests {
         let out = draw(&s, 100, 30);
         // Every rung, healthy ones included — the exonerating evidence is the
         // difference between a verdict and an assertion.
-        for label in ["machine", "gateway", "DNS", "ISP path", "internet", "destinations"] {
+        for label in [
+            "machine",
+            "gateway",
+            "DNS",
+            "ISP path",
+            "internet",
+            "destinations",
+        ] {
             assert!(out.contains(label), "ladder is missing {label:?}");
         }
         assert!(out.contains("cpu 8%"), "healthy rungs carry their data");
-        assert!(out.contains("[m] to watch"), "unknown rungs say how to fill them");
+        assert!(
+            out.contains("[m] to watch"),
+            "unknown rungs say how to fill them"
+        );
         assert!(out.contains("no findings"));
         assert!(out.contains("press y or Esc to close"));
     }
@@ -3077,7 +3105,10 @@ mod tests {
         let out = draw(&s, 120, 30);
         assert!(out.contains("locations (2)"));
         assert!(out.contains("Cafe"));
-        assert!(out.contains("(CoffeeNet)"), "auto label shown next to the name");
+        assert!(
+            out.contains("(CoffeeNet)"),
+            "auto label shown next to the name"
+        );
         assert!(out.contains("gateway ~4ms"));
         assert!(out.contains("speed 310↓/28↑"));
         assert!(out.contains("40 healthy min"));
@@ -3118,7 +3149,10 @@ mod tests {
         assert!(out.contains("▲ gateway unresponsive"));
         assert!(out.contains("VPN down"));
         assert!(out.contains("analysis"), "category label says analysis");
-        assert!(!out.contains("verdict"), "the word verdict is out of the UX");
+        assert!(
+            !out.contains("verdict"),
+            "the word verdict is out of the UX"
+        );
         assert!(out.contains("network"));
         // Newest (VPN down) renders above the older analysis event.
         assert!(out.find("VPN down").unwrap() < out.find("▲ gateway unresponsive").unwrap());
@@ -3129,10 +3163,8 @@ mod tests {
     #[test]
     fn web_strip_names_hops_as_non_destinations() {
         let mut s = AppState::new(vec![]);
-        let mut hop = crate::app::TargetStat::new(
-            "hop 2→1.1.1.1".into(),
-            "192.184.208.23".parse().unwrap(),
-        );
+        let mut hop =
+            crate::app::TargetStat::new("hop 2→1.1.1.1".into(), "192.184.208.23".parse().unwrap());
         hop.discovered = true;
         for _ in 0..10 {
             hop.record_reply(4.0);
@@ -3153,7 +3185,10 @@ mod tests {
         s.verdict.current = Verdict::Problems(vec![finding(Severity::Down)]);
         let out = draw(&s, 100, 30);
         assert!(out.contains("gateway unresponsive"));
-        assert!(!out.contains("likely"), "confidence words stay out of the UX");
+        assert!(
+            !out.contains("likely"),
+            "confidence words stay out of the UX"
+        );
         assert!(out.contains("gateway 192.168.1.1: 100% loss"));
     }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -6,13 +6,14 @@ use ratatui::prelude::*;
 use ratatui::style::Modifier;
 use ratatui::symbols::Marker;
 use ratatui::widgets::{
-    Axis, Block, Cell, Chart, Clear, Dataset, Gauge, GraphType, LineGauge, Paragraph, Row,
-    Sparkline, SparklineBar, Table, Wrap,
+    Axis, Block, Cell, Chart, Clear, Dataset, Gauge, GraphType, LineGauge, Padding, Paragraph,
+    Row, Sparkline, SparklineBar, Table, Wrap,
 };
 
 use crate::app::{
-    AppState, InputMode, LinkMedium, Panel, ProcStatus, QualityView, SpeedStatus, SubPane,
+    AppState, InputMode, LinkMedium, Overlay, Panel, ProcStatus, QualityView, SpeedStatus, SubPane,
 };
+use crate::verdict::{RungStatus, Severity, Verdict, thresholds as th};
 
 /// Draw the whole dashboard.
 pub fn render(f: &mut Frame, s: &AppState) {
@@ -49,11 +50,228 @@ pub fn render(f: &mut Frame, s: &AppState) {
 
     // Setup problems come first: with ICMP unavailable most of the dashboard is
     // dead, and a one-line footer notice is far too easy to miss.
-    if s.show_startup_notice {
-        startup_notice(f, s, f.area());
-    } else if s.show_help {
-        help_overlay(f, s, f.area());
+    match s.overlay {
+        Overlay::Startup => startup_notice(f, s, f.area()),
+        Overlay::Help => help_overlay(f, s, f.area()),
+        Overlay::Triage => triage_overlay(f, s, f.area()),
+        Overlay::Events => events_overlay(f, s, f.area()),
+        Overlay::Explainer => explainer_overlay(f, f.area()),
+        Overlay::Locations => locations_overlay(f, s, f.area()),
+        Overlay::None => {}
     }
+}
+
+/// Every stored network location with its learned baseline: what "normal"
+/// means at each place this machine has been.
+fn locations_overlay(f: &mut Frame, s: &AppState, area: Rect) {
+    let w = 84u16.min(area.width);
+    let h = (area.height * 4 / 5).max(8.min(area.height));
+    let rect = Rect {
+        x: area.x + (area.width.saturating_sub(w)) / 2,
+        y: area.y + (area.height.saturating_sub(h)) / 2,
+        width: w,
+        height: h,
+    };
+    // Three lines per location (name, stats, spacer).
+    let visible = (rect.height.saturating_sub(2) as usize) / 3;
+
+    let mut lines: Vec<Line> = Vec::new();
+    match &s.locations {
+        None => lines.push(Line::from(Span::styled(
+            "loading…",
+            Style::new().fg(Color::DarkGray),
+        ))),
+        Some(all) if all.is_empty() => {
+            lines.push(Line::from(Span::styled(
+                "no locations learned yet — baselines build up during healthy minutes",
+                Style::new().fg(Color::DarkGray),
+            )));
+        }
+        Some(all) => {
+            // Scroll only when there is somewhere to scroll to: with the list
+            // fully visible the offset stays pinned at zero.
+            let max_first = all.len().saturating_sub(visible.max(1));
+            let first = s.locations_sel.min(max_first);
+            let ms = |v: Option<f64>| v.map(|x| format!("~{x:.0}ms")).unwrap_or_else(|| "—".into());
+            for (key, b) in all.iter().skip(first).take(visible.max(1)) {
+                let current = s.baseline_key.as_deref() == Some(key.as_str());
+                let mut name_row = vec![Span::styled(
+                    b.display_name().to_string(),
+                    Style::new().fg(Color::White).bold(),
+                )];
+                if b.name.is_some() && b.name.as_deref() != Some(&b.label) {
+                    name_row.push(Span::styled(
+                        format!("  ({})", b.label),
+                        Style::new().fg(Color::DarkGray),
+                    ));
+                }
+                if current {
+                    name_row.push(Span::styled(
+                        "  ● current",
+                        Style::new().fg(Color::Cyan).bold(),
+                    ));
+                }
+                lines.push(Line::from(name_row));
+                let speed = match (b.down_mbps, b.up_mbps) {
+                    (Some(d), Some(u)) => format!(" · speed {d:.0}↓/{u:.0}↑"),
+                    _ => String::new(),
+                };
+                let rssi = b
+                    .rssi_dbm
+                    .map(|r| format!(" · rssi ~{r:.0}dBm"))
+                    .unwrap_or_default();
+                lines.push(Line::from(Span::styled(
+                    format!(
+                        "  gateway {} · internet {} · DNS {}{rssi}{speed} · {} healthy min",
+                        ms(b.gateway_ms),
+                        ms(b.anchor_ms),
+                        ms(b.dns_ms),
+                        b.samples
+                    ),
+                    Style::new().fg(Color::Gray),
+                )));
+                lines.push(Line::from(""));
+            }
+        }
+    }
+
+    let total = s.locations.as_ref().map(Vec::len).unwrap_or(0);
+    f.render_widget(Clear, rect);
+    let outer = Block::bordered()
+        .padding(Padding::new(1, 1, 0, 0))
+        .title(Span::styled(
+            format!(" octomon · locations ({total}) "),
+            Style::new().bold(),
+        ))
+        .title_bottom(Span::styled(
+            " ↑↓ scroll · [N] names the current network · press L or Esc to close ",
+            Style::new().fg(Color::DarkGray),
+        ))
+        .border_style(Style::new().fg(Color::Cyan));
+    let inner = outer.inner(rect);
+    f.render_widget(outer, rect);
+    f.render_widget(Paragraph::new(lines), inner);
+}
+
+/// First-run welcome: what the tool answers, and that it learns each network's
+/// normal. Shown once, then persisted away.
+fn explainer_overlay(f: &mut Frame, area: Rect) {
+    let head = |t: &str| Line::from(Span::styled(format!(" {t}"), Style::new().bold()));
+    let bullet = |t: &str| {
+        Line::from(vec![
+            Span::styled(" ● ", Style::new().fg(Color::Cyan)),
+            Span::styled(t.to_string(), Style::new().fg(Color::Gray)),
+        ])
+    };
+    let dim = |t: &str| Line::from(Span::styled(format!("   {t}"), Style::new().fg(Color::DarkGray)));
+
+    let lines = vec![
+        head("this tool helps you diagnose internet connectivity issues:"),
+        Line::from(Span::styled(
+            " \"Is it my machine, my local network, my ISP — or the internet?\"",
+            Style::new().fg(Color::Cyan).bold(),
+        )),
+        Line::from(""),
+        bullet("a live analysis at the bottom left of the screen"),
+        dim("press [y] anytime to see details"),
+        bullet("[e] shows a timeline of what changed and when"),
+        bullet("octomon learns what normal looks like on each network you use"),
+        dim("(gateway latency, DNS, signal — saved and judged per location,"),
+        dim("Name this network with [N], e.g. \"Home\"."),
+        bullet("everything stays on this machine"),
+        Line::from(""),
+        Line::from(Span::styled(
+            " give it a minute or two to learn before trusting comparisons",
+            Style::new().fg(Color::DarkGray).italic(),
+        )),
+    ];
+
+    // Breathing room inside the border: 1 column each side, 1 row above and
+    // below.
+    let pad = Padding::new(1, 1, 1, 1);
+    let w = (78u16 + 2).min(area.width);
+    let h = (lines.len() as u16 + 2 + 2).min(area.height);
+    let rect = Rect {
+        x: area.x + (area.width.saturating_sub(w)) / 2,
+        y: area.y + (area.height.saturating_sub(h)) / 2,
+        width: w,
+        height: h,
+    };
+    f.render_widget(Clear, rect);
+    let outer = Block::bordered()
+        .padding(pad)
+        .title(Span::styled(" octomon · welcome ", Style::new().bold()))
+        .title_bottom(Span::styled(
+            " press any key to start ",
+            Style::new().fg(Color::DarkGray),
+        ))
+        .border_style(Style::new().fg(Color::Cyan));
+    let inner = outer.inner(rect);
+    f.render_widget(outer, rect);
+    f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner);
+}
+
+/// The session timeline, newest first: what changed and when. This is the
+/// retroactive answer to "what happened during that call ten minutes ago?"
+fn events_overlay(f: &mut Frame, s: &AppState, area: Rect) {
+    // Big but not modal-window-pretending-to-be-a-screen: 80% each way.
+    let w = (area.width * 4 / 5).max(40.min(area.width));
+    let h = (area.height * 4 / 5).max(6.min(area.height));
+    let rect = Rect {
+        x: area.x + (area.width.saturating_sub(w)) / 2,
+        y: area.y + (area.height.saturating_sub(h)) / 2,
+        width: w,
+        height: h,
+    };
+    let visible = rect.height.saturating_sub(2) as usize;
+
+    let mut lines: Vec<Line> = Vec::new();
+    if s.events.is_empty() {
+        lines.push(Line::from(Span::styled(
+            " no events yet — network changes and analysis findings land here",
+            Style::new().fg(Color::DarkGray),
+        )));
+    }
+    for e in s.events.iter().rev().skip(s.events_scroll).take(visible) {
+        lines.push(Line::from(vec![
+            Span::styled(format!(" {}  ", e.when()), Style::new().fg(Color::DarkGray)),
+            Span::styled(
+                format!("{:<9} ", e.category.label()),
+                Style::new().fg(Color::Cyan),
+            ),
+            Span::styled(
+                e.message.clone(),
+                Style::new().fg(severity_color(e.severity)),
+            ),
+        ]));
+    }
+
+    let older = s
+        .events
+        .len()
+        .saturating_sub(s.events_scroll)
+        .saturating_sub(visible);
+    let title = format!(
+        " octomon · events ({} this session{}) ",
+        s.events_total,
+        if older > 0 {
+            format!(", ↓{older} older")
+        } else {
+            String::new()
+        }
+    );
+    f.render_widget(Clear, rect);
+    let outer = Block::bordered()
+        .padding(Padding::new(1, 1, 0, 0))
+        .title(Span::styled(title, Style::new().bold()))
+        .title_bottom(Span::styled(
+            " ↑↓ scroll · press e or Esc to close ",
+            Style::new().fg(Color::DarkGray),
+        ))
+        .border_style(Style::new().fg(Color::Cyan));
+    let inner = outer.inner(rect);
+    f.render_widget(outer, rect);
+    f.render_widget(Paragraph::new(lines), inner);
 }
 
 /// Modal shown once at startup when something will visibly not work. Dismissed
@@ -110,10 +328,11 @@ fn startup_notice(f: &mut Frame, s: &AppState, area: Rect) {
         return;
     }
 
-    let w = 76u16.min(area.width);
+    let w = 78u16.min(area.width);
     // Long guidance wraps, so counting logical lines under-measures and clips
     // the bottom of the modal — which is where the least-obvious advice sits.
-    let text_w = w.saturating_sub(2).max(1) as usize;
+    // Width available to text: border + 1-column padding each side.
+    let text_w = w.saturating_sub(4).max(1) as usize;
     let wrapped: usize = lines
         .iter()
         .map(|l| l.width().max(1).div_ceil(text_w))
@@ -127,6 +346,7 @@ fn startup_notice(f: &mut Frame, s: &AppState, area: Rect) {
     };
     f.render_widget(Clear, rect);
     let outer = Block::bordered()
+        .padding(Padding::new(1, 1, 0, 0))
         .title(Span::styled(" octomon · setup ", Style::new().bold()))
         .title_bottom(Span::styled(
             " press any key to continue ",
@@ -243,7 +463,14 @@ fn context_line(s: &AppState) -> Line<'static> {
                 txt("ull "),
             ]
         }
-        Panel::NetInfo => vec![key("[r]"), txt("efresh ")],
+        Panel::NetInfo => vec![
+            key("[r]"),
+            txt("efresh "),
+            key("[N]"),
+            txt("ame "),
+            key("[L]"),
+            txt("ocations "),
+        ],
         Panel::Vitals => vec![],
     };
     spans.push(key("[?]"));
@@ -252,31 +479,209 @@ fn context_line(s: &AppState) -> Line<'static> {
 }
 
 fn footer(f: &mut Frame, s: &AppState, area: Rect) {
-    let line = if s.input_mode == InputMode::AddTarget {
+    let input_line = |prompt: &str, buffer: &str, hint: &str| {
         Line::from(vec![
-            Span::styled(
-                " add target (IP or DNS): ",
-                Style::new().fg(Color::Yellow).bold(),
-            ),
-            Span::styled(s.input_buffer.clone(), Style::new().fg(Color::White)),
+            Span::styled(format!(" {prompt}"), Style::new().fg(Color::Yellow).bold()),
+            Span::styled(buffer.to_string(), Style::new().fg(Color::White)),
             Span::styled("▏", Style::new().fg(Color::Yellow)),
-            Span::styled(
-                "   [Enter] add  [Esc] cancel",
-                Style::new().fg(Color::DarkGray),
-            ),
+            Span::styled(format!("   {hint}"), Style::new().fg(Color::DarkGray)),
         ])
+    };
+    let line = if s.input_mode == InputMode::AddTarget {
+        input_line(
+            "add target (IP or DNS): ",
+            &s.input_buffer,
+            "[Enter] add  [Esc] cancel",
+        )
+    } else if s.input_mode == InputMode::NameNetwork {
+        input_line(
+            "name this network (Home, Office…): ",
+            &s.input_buffer,
+            "[Enter] save  [Esc] cancel",
+        )
     } else if let Some(n) = &s.notice {
         Line::from(Span::styled(
             format!(" {n}"),
             Style::new().fg(Color::Yellow),
         ))
     } else {
-        Line::from(Span::styled(
-            " [Tab] focus  [f] full  [p] pause  [r] refresh  [w] window  [s] speedtest  [l] log  [?] help  [q] quit",
+        verdict_line(s)
+    };
+
+    // While recording, the destination sits bottom-right so the analysis line
+    // keeps the left. Suppressed during text entry, which needs the width.
+    let rec = if s.input_mode == InputMode::Normal {
+        s.log.as_ref().map(|log| {
+            let name = log
+                .path
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_default();
+            format!("● rec → {name} ({} rows) ", log.rows)
+        })
+    } else {
+        None
+    };
+    match rec {
+        Some(r) => {
+            let cols =
+                Layout::horizontal([Constraint::Min(0), Constraint::Length(r.len() as u16)])
+                    .split(area);
+            f.render_widget(Paragraph::new(line), cols[0]);
+            f.render_widget(
+                Paragraph::new(Span::styled(r, Style::new().fg(Color::Red)))
+                    .alignment(Alignment::Right),
+                cols[1],
+            );
+        }
+        None => f.render_widget(Paragraph::new(line), area),
+    }
+}
+
+/// The always-visible one-liner: the verdict engine's headline. Full detail —
+/// every rung and finding — is one keypress away on [y], so this stays terse.
+fn verdict_line(s: &AppState) -> Line<'static> {
+    let hint = Span::styled("  [y] analysis", Style::new().fg(Color::DarkGray));
+    match &s.verdict.current {
+        Verdict::Insufficient(reason) => Line::from(vec![
+            Span::styled(format!(" ● {reason}"), Style::new().fg(Color::DarkGray)),
+            hint,
+        ]),
+        Verdict::Healthy => Line::from(vec![
+            Span::styled(" ● connection healthy", Style::new().fg(Color::Green)),
+            hint,
+        ]),
+        Verdict::Problems(findings) => {
+            let top = &findings[0];
+            // Info-class findings are notes, not problems: the line stays green
+            // rather than crying wolf over a busy CPU or a weak-but-working radio.
+            if top.severity == Severity::Info {
+                let n = findings.len();
+                return Line::from(vec![
+                    Span::styled(" ● connection healthy", Style::new().fg(Color::Green)),
+                    Span::styled(
+                        format!(
+                            " · {n} note{}: {}",
+                            if n == 1 { "" } else { "s" },
+                            top.summary
+                        ),
+                        Style::new().fg(Color::Gray),
+                    ),
+                    hint,
+                ]);
+            }
+            // Confidence wording lives in the [y] analysis overlay; the
+            // headline keeps just the claim.
+            let color = severity_color(top.severity);
+            let mut spans = vec![Span::styled(
+                format!(" ▲ {}", top.summary),
+                Style::new().fg(color).bold(),
+            )];
+            if findings.len() > 1 {
+                spans.push(Span::styled(
+                    format!("  (+{} more)", findings.len() - 1),
+                    Style::new().fg(Color::Yellow),
+                ));
+            }
+            spans.push(hint);
+            Line::from(spans)
+        }
+    }
+}
+
+fn severity_color(sev: Severity) -> Color {
+    match sev {
+        Severity::Down => Color::Red,
+        Severity::Degraded => Color::Yellow,
+        Severity::Info => Color::Gray,
+    }
+}
+
+/// The triage ladder: every subsystem's status with its data — healthy rungs
+/// included, so the verdict is auditable rather than oracular — then the active
+/// findings with their evidence.
+fn triage_overlay(f: &mut Frame, s: &AppState, area: Rect) {
+    let mut lines: Vec<Line> = Vec::new();
+
+    for r in &s.verdict.triage.rungs {
+        let (glyph, color) = match r.status {
+            RungStatus::Ok => ("✓", Color::Green),
+            RungStatus::Warn => ("~", Color::Yellow),
+            RungStatus::Bad => ("✗", Color::Red),
+            RungStatus::Unknown => ("?", Color::DarkGray),
+        };
+        lines.push(Line::from(vec![
+            Span::styled(format!(" {glyph} "), Style::new().fg(color).bold()),
+            Span::styled(
+                format!("{:<13}", r.area.label()),
+                Style::new().fg(Color::White),
+            ),
+            Span::styled(r.detail.clone(), Style::new().fg(Color::Gray)),
+        ]));
+    }
+
+    lines.push(Line::from(""));
+    match &s.verdict.current {
+        Verdict::Insufficient(reason) => {
+            lines.push(Line::from(Span::styled(
+                format!(" {reason}"),
+                Style::new().fg(Color::DarkGray),
+            )));
+        }
+        Verdict::Healthy => {
+            lines.push(Line::from(Span::styled(
+                " no findings — connection looks healthy",
+                Style::new().fg(Color::Green),
+            )));
+        }
+        Verdict::Problems(findings) => {
+            lines.push(Line::from(Span::styled(
+                " Findings",
+                Style::new().fg(Color::White).bold(),
+            )));
+            for finding in findings {
+                // Confidence stays internal (it drives the ranking); the
+                // evidence lines below make the case in words instead.
+                lines.push(Line::from(Span::styled(
+                    format!(" ▲ {}", finding.summary),
+                    Style::new().fg(severity_color(finding.severity)).bold(),
+                )));
+                for e in &finding.evidence {
+                    lines.push(Line::from(Span::styled(
+                        format!("     {e}"),
+                        Style::new().fg(Color::DarkGray),
+                    )));
+                }
+            }
+        }
+    }
+
+    let w = 78u16.min(area.width);
+    // Border + 1-column padding each side.
+    let text_w = w.saturating_sub(4).max(1) as usize;
+    let wrapped: usize = lines
+        .iter()
+        .map(|l| l.width().max(1).div_ceil(text_w))
+        .sum();
+    let h = (wrapped as u16 + 2).min(area.height);
+    let rect = Rect {
+        x: area.x + (area.width.saturating_sub(w)) / 2,
+        y: area.y + (area.height.saturating_sub(h)) / 2,
+        width: w,
+        height: h,
+    };
+    f.render_widget(Clear, rect);
+    let outer = Block::bordered()
+        .padding(Padding::new(1, 1, 0, 0))
+        .title(Span::styled(" octomon · analysis ", Style::new().bold()))
+        .title_bottom(Span::styled(
+            " press y or Esc to close, e for past events ",
             Style::new().fg(Color::DarkGray),
         ))
-    };
-    f.render_widget(Paragraph::new(line), area);
+        .border_style(Style::new().fg(Color::Cyan));
+    let inner = outer.inner(rect);
+    f.render_widget(outer, rect);
+    f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner);
 }
 
 fn block(title: &str, focused: bool) -> Block<'static> {
@@ -295,6 +700,17 @@ fn quality_panel(f: &mut Frame, s: &AppState, area: Rect) {
     // is — and the title needs the scroll counts, which depend on the layout.
     let inner = block("", false).inner(area);
 
+    // The web (HTTP) strip: hidden while a path view owns the bottom of a
+    // split panel, but full-screen has room for both; in split view it also
+    // needs a tall enough panel to not squeeze the latency chart.
+    let show_web = has_web_data(s)
+        && (s.fullscreen || (s.quality_view == QualityView::Graph && inner.height >= 13));
+    let web_h: u16 = match (show_web, s.fullscreen) {
+        (false, _) => 0,
+        (true, true) => 6,
+        (true, false) => 4,
+    };
+
     let parts = if s.quality_view == QualityView::Graph {
         // Full-screen: the target list takes only what it needs and the chart
         // fills the rest, since three overlaid series need the vertical room.
@@ -307,19 +723,18 @@ fn quality_panel(f: &mut Frame, s: &AppState, area: Rect) {
         } else {
             (Constraint::Min(3), Constraint::Length(6))
         };
-        Layout::vertical([Constraint::Length(1), list, graph]).split(inner)
+        Layout::vertical([list, graph, Constraint::Length(web_h)]).split(inner)
     } else {
         let table_h = (s.targets.len() as u16 + 2).min(9);
         Layout::vertical([
-            Constraint::Length(1),
             Constraint::Length(table_h),
             Constraint::Min(0),
+            Constraint::Length(web_h),
         ])
         .split(inner)
     };
 
     let n = s.window_samples();
-    quality_summary(f, s, n, parts[0]);
 
     let focused = s.focus == Panel::Quality && s.sub_pane == SubPane::Primary;
     // Sortable header: highlight the column cursor, mark the active sort ▲/▼.
@@ -353,7 +768,7 @@ fn quality_panel(f: &mut Frame, s: &AppState, area: Rect) {
     let order = s.quality_order();
     // Scroll so the cursor stays visible: with a path monitor open below, the
     // target list gets few rows and the selection would otherwise fall off it.
-    let rows_avail = (parts[1].height.saturating_sub(1)) as usize;
+    let rows_avail = (parts[0].height.saturating_sub(1)) as usize;
     let cursor = order.iter().position(|&i| i == s.selected).unwrap_or(0);
     let first = if rows_avail == 0 {
         0
@@ -407,7 +822,8 @@ fn quality_panel(f: &mut Frame, s: &AppState, area: Rect) {
         Constraint::Length(6),
     ];
     // Scroll counts live in the title: overlaying them on the header row
-    // clobbered whichever column happened to sit under them.
+    // clobbered whichever column happened to sit under them. They come before
+    // the stats so a narrow panel clips the stats, never the scroll cue.
     let mut title = "Connection Quality".to_string();
     if hidden_above > 0 || hidden_below > 0 {
         title.push_str(" · ");
@@ -419,13 +835,104 @@ fn quality_panel(f: &mut Frame, s: &AppState, area: Rect) {
         }
         title.push_str("more");
     }
+    // The stats that used to have their own row ride in the title now, buying
+    // the panel body an extra line of graph space.
+    title.push_str(&format!(" ({}", s.window_label()));
+    if s.window_is_capped() {
+        title.push_str(&format!(" capped at {}", s.window_samples()));
+    }
+    if let Some(t) = s.targets.get(s.graph_target) {
+        let st = t.stats(n);
+        title.push_str(&format!(" · {}: jit {:.1} · sd {:.1}", t.label, t.jitter_ms, st.stddev));
+        if let Some(bloat) = t.bufferbloat_ms(n) {
+            let (grade, _) = bufferbloat_grade(bloat);
+            title.push_str(&format!(" · bloat +{bloat:.0}ms {grade}"));
+        }
+    }
+    title.push(')');
     f.render_widget(block(&title, s.focus == Panel::Quality), area);
-    f.render_widget(Table::new(rows, widths).header(header), parts[1]);
+    f.render_widget(Table::new(rows, widths).header(header), parts[0]);
 
     match s.quality_view {
-        QualityView::Graph => latency_graph(f, s, n, parts[2]),
-        QualityView::Traceroute => traceroute_view(f, s, parts[2]),
-        QualityView::HopMonitor => hop_monitor_view(f, s, n, parts[2]),
+        QualityView::Graph => latency_graph(f, s, n, parts[1]),
+        QualityView::Traceroute => traceroute_view(f, s, parts[1]),
+        QualityView::HopMonitor => hop_monitor_view(f, s, n, parts[1]),
+    }
+    if show_web {
+        web_graph(f, s, parts[2]);
+    }
+}
+
+/// Whether the web strip has a target to describe.
+fn has_web_data(s: &AppState) -> bool {
+    s.targets.get(s.graph_target).is_some()
+}
+
+/// The web (HTTP) strip under the latency graph: the *graphed target's* web
+/// service, not the general internet (that check lives in the Network panel).
+/// A target that never served HTTP says so quietly — absence of a web server
+/// is a fact, not a fault.
+fn web_graph(f: &mut Frame, s: &AppState, area: Rect) {
+    if area.height < 2 {
+        return;
+    }
+    let Some(t) = s.targets.get(s.graph_target) else {
+        return;
+    };
+    use crate::app::WebStatus;
+    let rows = Layout::vertical([Constraint::Length(1), Constraint::Min(1)]).split(area);
+
+    let head = Span::styled(
+        format!(" web · {}  ", t.label),
+        Style::new().fg(Color::DarkGray),
+    );
+    // Mid-path hops are never probed — routers aren't web destinations, and
+    // "checking…" would be a promise that never resolves.
+    if t.is_path_hop() {
+        f.render_widget(
+            Paragraph::new(Line::from(vec![
+                head,
+                Span::styled(
+                    "mid-path router — not a web destination".to_string(),
+                    Style::new().fg(Color::DarkGray),
+                ),
+            ])),
+            rows[0],
+        );
+        return;
+    }
+    let detail = match t.web.status {
+        WebStatus::Web if t.web.fails > 0 => Span::styled(
+            format!("not answering ({} probes) — ping still fine", t.web.fails),
+            Style::new().fg(Color::Red).bold(),
+        ),
+        WebStatus::Web => Span::styled(
+            t.web
+                .last_ttfb_ms
+                .map(|ms| format!("ttfb {ms:.0}ms"))
+                .unwrap_or_else(|| "…".into()),
+            Style::new().fg(Color::Green),
+        ),
+        WebStatus::NoService => Span::styled(
+            "no web service (connection refused)".to_string(),
+            Style::new().fg(Color::DarkGray),
+        ),
+        WebStatus::Filtered => Span::styled(
+            "TCP filtered — ping answers, web dropped".to_string(),
+            Style::new().fg(Color::Yellow),
+        ),
+        WebStatus::Unknown => Span::styled("checking…".to_string(), Style::new().fg(Color::DarkGray)),
+    };
+    f.render_widget(Paragraph::new(Line::from(vec![head, detail])), rows[0]);
+
+    let data = t.web.hist.tail_u64(rows[1].width as usize);
+    if !data.is_empty() {
+        f.render_widget(
+            Sparkline::default()
+                .data(data.iter().map(|v| SparklineBar::from(*v)).collect::<Vec<_>>())
+                .style(Style::new().fg(SERIES_COLOR)),
+            rows[1],
+        );
     }
 }
 
@@ -777,8 +1284,8 @@ fn hop_chart(f: &mut Frame, m: &crate::app::HopMonitor, n: usize, area: Rect, ma
 /// tens of milliseconds are unremarkable.
 fn loss_color(pct: f64) -> Color {
     match pct {
-        p if p >= 5.0 => Color::Red,
-        p if p >= 1.0 => Color::Yellow,
+        p if p >= th::LOSS_BAD_PCT => Color::Red,
+        p if p >= th::LOSS_WARN_PCT => Color::Yellow,
         p if p > 0.0 => Color::Rgb(200, 200, 120),
         _ => Color::Green,
     }
@@ -940,58 +1447,18 @@ fn latency_graph(f: &mut Frame, s: &AppState, n: usize, area: Rect) {
     f.render_widget(chart, area);
 }
 
-/// One-line summary above the table: stats window, and jitter / stddev /
-/// bufferbloat for the graphed target.
-fn quality_summary(f: &mut Frame, s: &AppState, n: usize, area: Rect) {
-    let mut spans = vec![
-        Span::styled(
-            format!("window {} ", s.window_label()),
-            Style::new().fg(Color::Gray),
-        ),
-        Span::styled("[w]", Style::new().fg(Color::Cyan)),
-        Span::raw("  "),
-    ];
-    // Say when the buffer, not the chosen window, is setting the reach. The
-    // figures are still honest — they just cover less than the label implies,
-    // and silently overstating them is worse than one extra clause.
-    if s.window_is_capped() {
-        spans.push(Span::styled(
-            format!("(capped at {} samples)  ", s.window_samples()),
-            Style::new().fg(Color::Yellow),
-        ));
-    }
-    if let Some(t) = s.targets.get(s.graph_target) {
-        let st = t.stats(n);
-        spans.push(Span::styled(
-            format!("{}: ", t.label),
-            Style::new().fg(Color::DarkGray),
-        ));
-        spans.push(Span::styled(
-            format!("jitter {:.1} · stddev {:.1}  ", t.jitter_ms, st.stddev),
-            Style::new().fg(Color::Gray),
-        ));
-        if let Some(bloat) = t.bufferbloat_ms(n) {
-            let (grade, color) = bufferbloat_grade(bloat);
-            spans.push(Span::styled(
-                "bufferbloat ",
-                Style::new().fg(Color::DarkGray),
-            ));
-            spans.push(Span::styled(
-                format!("+{bloat:.0}ms ({grade})"),
-                Style::new().fg(color).bold(),
-            ));
-        }
-    }
-    f.render_widget(Paragraph::new(Line::from(spans)), area);
-}
+// (The one-line stats summary that used to sit above the target table now
+// rides in the panel title, buying a line of graph space.)
 
 /// Grade latency inflation under load, à la the Waveform/Cloudflare scale.
+/// Steps live in the verdict rulebook so grading here and findings there agree.
 fn bufferbloat_grade(bloat_ms: f64) -> (&'static str, Color) {
+    let [excellent, good, moderate, poor] = th::BLOAT_STEPS_MS;
     match bloat_ms {
-        b if b < 5.0 => ("excellent", Color::Green),
-        b if b < 30.0 => ("good", Color::Green),
-        b if b < 60.0 => ("moderate", Color::Yellow),
-        b if b < 200.0 => ("poor", Color::Red),
+        b if b < excellent => ("excellent", Color::Green),
+        b if b < good => ("good", Color::Green),
+        b if b < moderate => ("moderate", Color::Yellow),
+        b if b < poor => ("poor", Color::Red),
         _ => ("bad", Color::Red),
     }
 }
@@ -1359,19 +1826,20 @@ fn top_talkers(f: &mut Frame, s: &AppState, area: Rect, limit: usize) {
 fn help_overlay(f: &mut Frame, s: &AppState, area: Rect) {
     let row = |k: &str, d: &str| {
         Line::from(vec![
-            Span::styled(format!(" {k:<11}"), Style::new().fg(Color::Cyan)),
+            Span::styled(format!("{k:<11}"), Style::new().fg(Color::Cyan)),
             Span::styled(d.to_string(), Style::new().fg(Color::Gray)),
         ])
     };
     let head = |t: &str| {
         Line::from(Span::styled(
-            format!(" {t}"),
+            t.to_string(),
             Style::new().fg(Color::White).bold(),
         ))
     };
 
     // Two columns, so the whole key set fits an 80x24 terminal without
     // scrolling. Descriptions are kept short enough for a half-width column.
+    // Leading indent comes from the block's padding, not the lines.
     let mut left = vec![
         head("Global"),
         row("Tab / ⇧Tab", "cycle panels"),
@@ -1383,6 +1851,8 @@ fn help_overlay(f: &mut Frame, s: &AppState, area: Rect) {
         row("r", "re-probe network info"),
         row("w", "stats window 1m/5m/15m"),
         row("l", "start / stop CSV recording"),
+        row("y", "connection analysis"),
+        row("e", "event timeline"),
         row("?", "toggle this help"),
         row("q / Ctrl+C", "quit"),
         Line::from(""),
@@ -1409,6 +1879,8 @@ fn help_overlay(f: &mut Frame, s: &AppState, area: Rect) {
         Line::from(""),
         head("Network"),
         row("r", "re-probe"),
+        row("N", "name this network"),
+        row("L", "saved network locations"),
         row("f", "full-screen for DNS graphs"),
     ];
 
@@ -1417,12 +1889,12 @@ fn help_overlay(f: &mut Frame, s: &AppState, area: Rect) {
     if !s.missing_tools.is_empty() {
         right.push(Line::from(""));
         right.push(Line::from(Span::styled(
-            " Missing tools",
+            "Missing tools",
             Style::new().fg(Color::Yellow).bold(),
         )));
         for (name, _provides, package) in &s.missing_tools {
             right.push(Line::from(vec![
-                Span::styled(format!(" {name:<11}"), Style::new().fg(Color::Yellow)),
+                Span::styled(format!("{name:<11}"), Style::new().fg(Color::Yellow)),
                 Span::styled(package.to_string(), Style::new().fg(Color::DarkGray)),
             ]));
         }
@@ -1450,6 +1922,7 @@ fn help_overlay(f: &mut Frame, s: &AppState, area: Rect) {
 
     f.render_widget(Clear, rect);
     let outer = Block::bordered()
+        .padding(Padding::new(1, 1, 0, 0))
         .title(Span::styled(
             format!(" octomon v{} · Shortcuts ", env!("CARGO_PKG_VERSION")),
             Style::new().bold(),
@@ -1480,7 +1953,13 @@ fn help_overlay(f: &mut Frame, s: &AppState, area: Rect) {
 
 fn netinfo_panel(f: &mut Frame, s: &AppState, area: Rect) {
     let n = &s.netinfo;
-    let b = block("Network", s.focus == Panel::NetInfo);
+    // The location name rides in the title, like the Bandwidth panel's iface:
+    // "Network · Home". Until a baseline exists there is nothing to say.
+    let title = match &s.baseline {
+        Some(b) => format!("Network · {}", b.display_name()),
+        None => "Network".to_string(),
+    };
+    let b = block(&title, s.focus == Panel::NetInfo);
     let inner = b.inner(area);
     f.render_widget(b, area);
 
@@ -1597,6 +2076,9 @@ fn netinfo_panel(f: &mut Frame, s: &AppState, area: Rect) {
     }
 
     lines.push(dns_line(s));
+    if let Some(l) = http_line(s) {
+        lines.push(l);
+    }
 
     if let Some(w) = &n.wifi {
         // Live signal/tx come from the CoreWLAN graph below; keep the slower
@@ -1850,12 +2332,42 @@ fn dns_line(s: &AppState) -> Line<'static> {
     Line::from(spans)
 }
 
+/// The internet-level HTTP check ("can I reach the internet the way a browser
+/// does"), one Network-panel line — a property of the network, unlike the
+/// per-target web strip in Connection Quality. Absent until a probe lands.
+fn http_line(s: &AppState) -> Option<Line<'static>> {
+    use crate::app::FamilyProbe as FP;
+    if matches!(s.http.v4, FP::NotRun) && matches!(s.http.v6, FP::NotRun) {
+        return None;
+    }
+    let span = |f: &FP, name: &str| match f {
+        FP::NotRun => Span::styled(format!("{name} …"), Style::new().fg(Color::DarkGray)),
+        FP::NotApplicable => Span::styled(format!("{name} n/a"), Style::new().fg(Color::DarkGray)),
+        FP::Ok(ms) => Span::styled(format!("{name} ok {ms:.0}ms"), Style::new().fg(Color::Green)),
+        FP::Captive(_) => Span::styled(
+            "CAPTIVE PORTAL".to_string(),
+            Style::new().fg(Color::Red).bold(),
+        ),
+        FP::Fail(r) => Span::styled(format!("{name} {r}"), Style::new().fg(Color::Red)),
+    };
+    Some(Line::from(vec![
+        Span::styled(format!("{:<9}", "http"), Style::new().fg(Color::DarkGray)),
+        span(&s.http.v4, "v4"),
+        Span::styled(" · ", Style::new().fg(Color::DarkGray)),
+        span(&s.http.v6, "v6"),
+        Span::styled(
+            format!("  ({})", s.http.provider),
+            Style::new().fg(Color::DarkGray),
+        ),
+    ]))
+}
+
 /// Resolver latency thresholds: a cached answer should be near the RTT to the
 /// resolver, so tens of ms is fine and hundreds is not.
 fn dns_color(ms: f64) -> Color {
     match ms {
-        v if v < 30.0 => Color::Green,
-        v if v < 120.0 => Color::Yellow,
+        v if v < th::DNS_WARN_MS => Color::Green,
+        v if v < th::DNS_BAD_MS => Color::Yellow,
         _ => Color::Red,
     }
 }
@@ -2353,8 +2865,8 @@ fn fmt_bytes(n: u64) -> String {
 /// measurement in isolation, so a trace can show what each moment looked like.
 fn rtt_color(ms: f64) -> Color {
     match ms {
-        v if v < 50.0 => Color::Green,
-        v if v < 150.0 => Color::Yellow,
+        v if v < th::RTT_WARN_MS => Color::Green,
+        v if v < th::RTT_BAD_MS => Color::Yellow,
         _ => Color::Red,
     }
 }
@@ -2367,16 +2879,15 @@ const P95_COLOR: Color = Color::Magenta;
 const JITTER_COLOR: Color = Color::LightBlue;
 
 fn latency_color(last: Option<f64>, loss: f64) -> Color {
-    if loss >= 5.0 || last.is_none() {
+    if loss >= th::LOSS_BAD_PCT || last.is_none() {
         return Color::Red;
     }
-    if loss >= 1.0 {
+    if loss >= th::LOSS_WARN_PCT {
         return Color::Yellow;
     }
     match last {
-        Some(ms) if ms < 50.0 => Color::Green,
-        Some(ms) if ms < 150.0 => Color::Yellow,
-        _ => Color::Red,
+        Some(ms) => rtt_color(ms),
+        None => Color::Red,
     }
 }
 
@@ -2391,9 +2902,9 @@ fn medium_color(m: LinkMedium) -> Color {
 }
 
 fn usage_color(pct: f32) -> Color {
-    if pct >= 85.0 {
+    if pct >= th::USAGE_BAD_PCT {
         Color::Red
-    } else if pct >= 60.0 {
+    } else if pct >= th::USAGE_WARN_PCT {
         Color::Yellow
     } else {
         Color::Green
@@ -2424,6 +2935,226 @@ mod tests {
         s.netinfo.iface = "en0".to_string();
         s.netinfo.medium = medium;
         s
+    }
+
+    fn finding(severity: Severity) -> crate::verdict::Finding {
+        crate::verdict::Finding {
+            cause: crate::verdict::Cause::GatewayLan,
+            severity,
+            confidence: crate::verdict::Confidence::Likely,
+            summary: "gateway unresponsive (100% loss)".into(),
+            evidence: vec!["gateway 192.168.1.1: 100% loss".into()],
+            subject: String::new(),
+        }
+    }
+
+    #[test]
+    fn footer_carries_the_verdict_headline() {
+        // Fresh state: measuring, never "healthy" from ignorance.
+        let s = AppState::new(vec![]);
+        let out = draw(&s, 120, 24);
+        assert!(out.contains("measuring"));
+        assert!(out.contains("[y] analysis"));
+
+        let mut s = AppState::new(vec![]);
+        s.verdict.current = Verdict::Healthy;
+        assert!(draw(&s, 120, 24).contains("connection healthy"));
+
+        s.verdict.current = Verdict::Problems(vec![
+            finding(Severity::Down),
+            finding(Severity::Degraded),
+        ]);
+        let out = draw(&s, 120, 24);
+        assert!(out.contains("gateway unresponsive"));
+        // Confidence wording stays in the [y] overlay, off the headline.
+        assert!(!out.contains("— likely"));
+        assert!(out.contains("+1 more"), "co-causes must stay visible");
+
+        // Info-class findings are notes, not a red headline.
+        s.verdict.current = Verdict::Problems(vec![finding(Severity::Info)]);
+        let out = draw(&s, 120, 24);
+        assert!(out.contains("connection healthy"));
+        assert!(out.contains("1 note"));
+    }
+
+    #[test]
+    fn transient_notice_still_outranks_the_verdict_line() {
+        let mut s = AppState::new(vec![]);
+        s.verdict.current = Verdict::Healthy;
+        s.notice = Some("network changed → en7".into());
+        let out = draw(&s, 120, 24);
+        assert!(out.contains("network changed"));
+        assert!(!out.contains("connection healthy"));
+    }
+
+    #[test]
+    fn triage_overlay_shows_the_whole_ladder_with_its_data() {
+        let mut s = AppState::new(vec![
+            crate::app::TargetStat::new("Cloudflare".into(), "1.1.1.1".parse().unwrap()),
+        ]);
+        for _ in 0..20 {
+            s.targets[0].record_reply(12.0);
+        }
+        s.vitals.cores = vec![10.0; 4];
+        s.vitals.cpu_pct = 8.0;
+        s.overlay = Overlay::Triage;
+        let triage = crate::verdict::evaluate(&s);
+        s.verdict.triage = triage;
+        s.verdict.current = Verdict::Healthy;
+
+        let out = draw(&s, 100, 30);
+        // Every rung, healthy ones included — the exonerating evidence is the
+        // difference between a verdict and an assertion.
+        for label in ["machine", "gateway", "DNS", "ISP path", "internet", "destinations"] {
+            assert!(out.contains(label), "ladder is missing {label:?}");
+        }
+        assert!(out.contains("cpu 8%"), "healthy rungs carry their data");
+        assert!(out.contains("[m] to watch"), "unknown rungs say how to fill them");
+        assert!(out.contains("no findings"));
+        assert!(out.contains("press y or Esc to close"));
+    }
+
+    #[test]
+    fn explainer_overlay_reads_as_a_welcome() {
+        let mut s = AppState::new(vec![]);
+        s.overlay = Overlay::Explainer;
+        let out = draw(&s, 100, 30);
+        assert!(out.contains("diagnose internet connectivity"));
+        assert!(out.contains("my machine, my local network, my ISP"));
+        assert!(out.contains("learns what normal looks like"));
+        assert!(out.contains("press any key to start"));
+    }
+
+    #[test]
+    fn network_panel_title_carries_the_location_name() {
+        let mut s = state_with_medium(LinkMedium::WiFi);
+        // No baseline yet: plain title.
+        let out = draw(&s, 200, 60);
+        assert!(out.contains(" Network "));
+        assert!(!out.contains("Network · "));
+
+        s.baseline = Some(crate::baseline::Baseline {
+            label: "HomeNet".into(),
+            samples: 0,
+            ..Default::default()
+        });
+        assert!(draw(&s, 200, 60).contains("Network · HomeNet"));
+
+        // A user-chosen name wins over the auto label.
+        s.baseline.as_mut().unwrap().name = Some("Home".into());
+        assert!(draw(&s, 200, 60).contains("Network · Home"));
+    }
+
+    #[test]
+    fn locations_overlay_lists_stored_baselines() {
+        let mut s = AppState::new(vec![]);
+        s.overlay = Overlay::Locations;
+        assert!(draw(&s, 120, 30).contains("loading…"));
+
+        s.baseline_key = Some("k2".into());
+        s.locations = Some(vec![
+            (
+                "k1".into(),
+                crate::baseline::Baseline {
+                    label: "CoffeeNet".into(),
+                    name: Some("Cafe".into()),
+                    samples: 40,
+                    gateway_ms: Some(4.2),
+                    down_mbps: Some(310.0),
+                    up_mbps: Some(28.0),
+                    ..Default::default()
+                },
+            ),
+            (
+                "k2".into(),
+                crate::baseline::Baseline {
+                    label: "HomeNet".into(),
+                    samples: 2,
+                    ..Default::default()
+                },
+            ),
+        ]);
+        let out = draw(&s, 120, 30);
+        assert!(out.contains("locations (2)"));
+        assert!(out.contains("Cafe"));
+        assert!(out.contains("(CoffeeNet)"), "auto label shown next to the name");
+        assert!(out.contains("gateway ~4ms"));
+        assert!(out.contains("speed 310↓/28↑"));
+        assert!(out.contains("40 healthy min"));
+        assert!(out.contains("● current"), "the active network is marked");
+        assert!(out.contains("press L or Esc to close"));
+    }
+
+    #[test]
+    fn naming_prompt_takes_over_the_footer() {
+        let mut s = AppState::new(vec![]);
+        s.input_mode = InputMode::NameNetwork;
+        s.input_buffer = "Home".into();
+        let out = draw(&s, 120, 24);
+        assert!(out.contains("name this network"));
+        assert!(out.contains("Home"));
+        assert!(out.contains("[Enter] save"));
+    }
+
+    #[test]
+    fn events_overlay_lists_newest_first_with_times() {
+        let mut s = AppState::new(vec![]);
+        s.overlay = Overlay::Events;
+        let out = draw(&s, 120, 30);
+        assert!(out.contains("no events yet"));
+
+        s.push_event(
+            Severity::Degraded,
+            crate::app::EventCategory::Analysis,
+            "▲ gateway unresponsive".into(),
+        );
+        s.push_event(
+            Severity::Info,
+            crate::app::EventCategory::Network,
+            "VPN down".into(),
+        );
+        let out = draw(&s, 120, 30);
+        assert!(out.contains("events (2 this session)"));
+        assert!(out.contains("▲ gateway unresponsive"));
+        assert!(out.contains("VPN down"));
+        assert!(out.contains("analysis"), "category label says analysis");
+        assert!(!out.contains("verdict"), "the word verdict is out of the UX");
+        assert!(out.contains("network"));
+        // Newest (VPN down) renders above the older analysis event.
+        assert!(out.find("VPN down").unwrap() < out.find("▲ gateway unresponsive").unwrap());
+        assert!(out.contains("press e or Esc to close"));
+    }
+
+    /// A graphed mid-path hop must not promise a web check that never comes.
+    #[test]
+    fn web_strip_names_hops_as_non_destinations() {
+        let mut s = AppState::new(vec![]);
+        let mut hop = crate::app::TargetStat::new(
+            "hop 2→1.1.1.1".into(),
+            "192.184.208.23".parse().unwrap(),
+        );
+        hop.discovered = true;
+        for _ in 0..10 {
+            hop.record_reply(4.0);
+        }
+        s.targets.push(hop);
+        s.graph_target = 0;
+        s.fullscreen = true; // guarantees the web strip is drawn
+        let out = draw(&s, 120, 40);
+        assert!(out.contains("mid-path router — not a web destination"));
+        assert!(!out.contains("checking…"));
+    }
+
+    #[test]
+    fn triage_overlay_lists_findings_with_evidence() {
+        let mut s = AppState::new(vec![]);
+        s.overlay = Overlay::Triage;
+        s.verdict.triage = crate::verdict::evaluate(&s);
+        s.verdict.current = Verdict::Problems(vec![finding(Severity::Down)]);
+        let out = draw(&s, 100, 30);
+        assert!(out.contains("gateway unresponsive"));
+        assert!(!out.contains("likely"), "confidence words stay out of the UX");
+        assert!(out.contains("gateway 192.168.1.1: 100% loss"));
     }
 
     #[test]
@@ -2906,7 +3637,7 @@ mod tests {
     #[test]
     fn help_lists_every_key_and_fits_a_standard_terminal() {
         let mut s = AppState::new(vec![]);
-        s.show_help = true;
+        s.overlay = Overlay::Help;
         let out = draw(&s, 80, 24);
         for c in out.as_bytes().chunks(80) {
             println!("{}", String::from_utf8_lossy(c).trim_end());
@@ -2934,6 +3665,9 @@ mod tests {
             "t",
             "m",
             "v",
+            "y",
+            "e",
+            "N",
         ] {
             assert!(out.contains(key), "help is missing a binding for {key:?}");
         }
@@ -2966,7 +3700,7 @@ mod tests {
     #[test]
     fn help_falls_back_to_one_column_when_narrow() {
         let mut s = AppState::new(vec![]);
-        s.show_help = true;
+        s.overlay = Overlay::Help;
         let out = draw(&s, 50, 40);
         assert!(out.contains("Connection Quality"));
         assert!(out.contains("cycle panels"));
@@ -2975,7 +3709,7 @@ mod tests {
     #[test]
     fn help_shows_the_version_and_fits_its_content() {
         let mut s = AppState::new(vec![]);
-        s.show_help = true;
+        s.overlay = Overlay::Help;
         let out = draw(&s, 200, 60);
         assert!(out.contains(&format!("octomon v{}", env!("CARGO_PKG_VERSION"))));
         // The last section used to fall off the bottom of a fixed 22-row box.

--- a/src/verdict.rs
+++ b/src/verdict.rs
@@ -173,13 +173,20 @@ pub struct Finding {
 /// except caveat-class causes always sort after network causes.
 fn rank(findings: &mut [Finding]) {
     findings.sort_by(|a, b| {
-        (a.cause.is_caveat(), b.severity, b.confidence, a.cause, &a.subject).cmp(&(
-            b.cause.is_caveat(),
-            a.severity,
-            a.confidence,
-            b.cause,
-            &b.subject,
-        ))
+        (
+            a.cause.is_caveat(),
+            b.severity,
+            b.confidence,
+            a.cause,
+            &a.subject,
+        )
+            .cmp(&(
+                b.cause.is_caveat(),
+                a.severity,
+                a.confidence,
+                b.cause,
+                &b.subject,
+            ))
     });
 }
 
@@ -310,7 +317,11 @@ fn gateway_target(s: &AppState) -> Option<&TargetStat> {
     s.targets
         .iter()
         .find(|t| t.discovered && t.addr.to_string() == s.netinfo.gateway_ip)
-        .or_else(|| s.targets.iter().find(|t| t.discovered && t.label == "gateway"))
+        .or_else(|| {
+            s.targets
+                .iter()
+                .find(|t| t.discovered && t.label == "gateway")
+        })
 }
 
 /// Why no verdict can be given yet, or `None` once there is enough to judge.
@@ -329,10 +340,7 @@ pub fn insufficient_reason(s: &AppState) -> Option<String> {
         };
     }
     let warmed = s.started.elapsed().as_secs() >= th::WARMUP_SECS;
-    let sampled = s
-        .targets
-        .iter()
-        .any(|t| t.window.len() >= th::MIN_SAMPLES);
+    let sampled = s.targets.iter().any(|t| t.window.len() >= th::MIN_SAMPLES);
     if !warmed || !sampled {
         return Some("measuring…".to_string());
     }
@@ -510,8 +518,7 @@ pub fn evaluate(s: &AppState) -> Triage {
     let probes: Vec<&crate::app::DnsProbe> = s.dns.iter().filter(|p| p.sent >= 3).collect();
     if !probes.is_empty() {
         let failing = |p: &crate::app::DnsProbe| p.fail_pct() >= 50.0;
-        let slow =
-            |p: &crate::app::DnsProbe| p.mean_ms().is_some_and(|m| m > th::DNS_BAD_MS);
+        let slow = |p: &crate::app::DnsProbe| p.mean_ms().is_some_and(|m| m > th::DNS_BAD_MS);
         let n_fail = probes.iter().filter(|p| failing(p)).count();
         let n_slow = probes.iter().filter(|p| !failing(p) && slow(p)).count();
         // The anchors-fine contrast is the whole point: ping works, names don't.
@@ -593,7 +600,10 @@ pub fn evaluate(s: &AppState) -> Triage {
                 cause: Cause::Dns,
                 severity: Severity::Info,
                 confidence: Confidence::Weak,
-                summary: format!("{n_fail} of {} DNS resolvers failing — others fine", probes.len()),
+                summary: format!(
+                    "{n_fail} of {} DNS resolvers failing — others fine",
+                    probes.len()
+                ),
                 evidence,
                 subject: String::new(),
             });
@@ -606,7 +616,11 @@ pub fn evaluate(s: &AppState) -> Triage {
         let all_down = bad
             .iter()
             .all(|t| t.recent_loss_pct(th::RECENT) >= th::LOSS_DOWN_PCT);
-        let severity = if all_down { Severity::Down } else { Severity::Degraded };
+        let severity = if all_down {
+            Severity::Down
+        } else {
+            Severity::Degraded
+        };
         let mut evidence: Vec<String> = vec![format!(
             "gateway fine ({}, {:.0}% loss) but {} of {} anchors failing",
             fmt_ms(gw.and_then(|g| g.last_rtt_ms)),
@@ -693,12 +707,10 @@ pub fn evaluate(s: &AppState) -> Triage {
     {
         use crate::app::FamilyProbe as FP;
         let http = &s.http;
-        let captive = [&http.v4, &http.v6]
-            .into_iter()
-            .find_map(|f| match f {
-                FP::Captive(loc) => Some(loc.clone()),
-                _ => None,
-            });
+        let captive = [&http.v4, &http.v6].into_iter().find_map(|f| match f {
+            FP::Captive(loc) => Some(loc.clone()),
+            _ => None,
+        });
         if let Some(location) = captive {
             let mut evidence = vec![format!(
                 "{} connectivity check answered with a sign-in page",
@@ -728,10 +740,7 @@ pub fn evaluate(s: &AppState) -> Triage {
                 ],
                 subject: String::new(),
             });
-        } else if matches!(http.v4, FP::Fail(_))
-            && !matches!(http.v6, FP::Ok(_))
-            && fine >= 2
-        {
+        } else if matches!(http.v4, FP::Fail(_)) && !matches!(http.v6, FP::Ok(_)) && fine >= 2 {
             let reason = match &http.v4 {
                 FP::Fail(r) => r.clone(),
                 _ => String::new(),
@@ -835,10 +844,7 @@ pub fn evaluate(s: &AppState) -> Triage {
             severity: Severity::Info,
             confidence: Confidence::Likely,
             summary: format!("machine under load (cpu {:.0}%)", v.cpu_pct),
-            evidence: vec![format!(
-                "cpu {:.0}%, hottest core {hottest:.0}%",
-                v.cpu_pct
-            )],
+            evidence: vec![format!("cpu {:.0}%, hottest core {hottest:.0}%", v.cpu_pct)],
             subject: "cpu".to_string(),
         });
     }
@@ -1285,7 +1291,6 @@ impl VerdictState {
         self.triage = triage;
         transitions
     }
-
 }
 
 /// The triage ladder + findings as plain text — doctor mode's `== VERDICT ==`
@@ -1343,7 +1348,10 @@ pub fn exit_code(triage: &Triage, insufficient: bool) -> i32 {
 enum BaselineIo {
     None,
     /// The network changed: load (or create) its baseline.
-    Load { key: String, label: String },
+    Load {
+        key: String,
+        label: String,
+    },
     /// A healthy minute was folded in: persist.
     Save {
         key: String,
@@ -1411,10 +1419,9 @@ pub async fn run(state: std::sync::Arc<std::sync::Mutex<AppState>>, cfg: crate::
                 }
             }
             BaselineIo::Save { key, baseline } => {
-                let _ = tokio::task::spawn_blocking(move || {
-                    crate::baseline::save_one(&key, &baseline)
-                })
-                .await;
+                let _ =
+                    tokio::task::spawn_blocking(move || crate::baseline::save_one(&key, &baseline))
+                        .await;
             }
         }
     }
@@ -1662,7 +1669,12 @@ mod tests {
 
         let t = evaluate(&s);
         let f = t.findings.iter().find(|f| f.cause == Cause::Dns).unwrap();
-        assert_eq!(f.severity, Severity::Info, "not a Down claim: {}", f.summary);
+        assert_eq!(
+            f.severity,
+            Severity::Info,
+            "not a Down claim: {}",
+            f.summary
+        );
         assert!(f.summary.contains("names still resolve"));
         assert!(f.evidence.iter().any(|e| e.contains("HTTP check")));
     }
@@ -1679,7 +1691,11 @@ mod tests {
             t
         });
         let t = evaluate(&s);
-        let f = t.findings.iter().find(|f| f.cause == Cause::WebTarget).unwrap();
+        let f = t
+            .findings
+            .iter()
+            .find(|f| f.cause == Cause::WebTarget)
+            .unwrap();
         assert_eq!(f.subject, "bbc.co.uk");
         assert!(f.summary.contains("ping still fine"));
 
@@ -1775,7 +1791,12 @@ mod tests {
         s.http.v6 = FamilyProbe::NotApplicable;
         let t = evaluate(&s);
         let f = &t.findings[0];
-        assert_eq!(f.cause, Cause::CaptivePortal, "sign-in page first: {:?}", causes(&t));
+        assert_eq!(
+            f.cause,
+            Cause::CaptivePortal,
+            "sign-in page first: {:?}",
+            causes(&t)
+        );
         assert_eq!(f.severity, Severity::Down);
         assert!(f.evidence.iter().any(|e| e.contains("portal.cafe")));
     }
@@ -1897,7 +1918,10 @@ mod tests {
         let mut healthy_run = 59;
         let mut last_speed = Some(0);
         let io = baseline_step(&mut s, &mut healthy_run, &mut last_speed);
-        assert!(matches!(io, BaselineIo::Save { .. }), "60th healthy tick folds");
+        assert!(
+            matches!(io, BaselineIo::Save { .. }),
+            "60th healthy tick folds"
+        );
         assert_eq!(s.baseline.as_ref().unwrap().samples, 1);
 
         // Now a finding is active: the fold that was one tick away is denied
@@ -1968,7 +1992,10 @@ mod tests {
             );
         }
         let transitions = vs.ingest(without.clone(), None, now);
-        assert!(matches!(vs.current, Verdict::Healthy), "8th quiet tick clears");
+        assert!(
+            matches!(vs.current, Verdict::Healthy),
+            "8th quiet tick clears"
+        );
         let cleared = transitions.iter().find(|t| !t.raised).unwrap();
         assert!(cleared.after.is_some(), "clears carry the active duration");
     }
@@ -2039,7 +2066,10 @@ mod tests {
         let out = render_text(&evaluate(&s), None);
         assert!(out.starts_with("== ANALYSIS =="));
         assert!(out.contains("✓ gateway"));
-        assert!(out.contains("? ISP path"), "unmeasured stays a question mark");
+        assert!(
+            out.contains("? ISP path"),
+            "unmeasured stays a question mark"
+        );
         assert!(out.contains("no findings"));
 
         for t in &mut s.targets {
@@ -2053,7 +2083,10 @@ mod tests {
         assert!(!out.contains("— strong"));
         assert!(out.contains("% loss, last"), "evidence lines included");
 
-        let out = render_text(&Triage::default(), Some("ICMP unavailable — cannot measure"));
+        let out = render_text(
+            &Triage::default(),
+            Some("ICMP unavailable — cannot measure"),
+        );
         assert!(out.contains("ICMP unavailable"));
     }
 

--- a/src/verdict.rs
+++ b/src/verdict.rs
@@ -1,0 +1,2091 @@
+//! The verdict engine: the one component that *interprets* what the collectors
+//! measure. [`evaluate`] is a pure read of [`AppState`] producing a [`Triage`] —
+//! every subsystem's status (healthy rungs included, so the conclusion is
+//! auditable) plus ranked problem [`Finding`]s. [`VerdictState`] applies
+//! hysteresis on top so the footer verdict doesn't flap on a single lost packet.
+//!
+//! Nothing here suppresses anything: simultaneous causes are all reported, and
+//! contradictory evidence lowers confidence rather than picking a side. Caveat
+//! findings (machine load, VPN) are co-reported but never rank above network
+//! causes — a busy CPU doesn't disprove a dead gateway.
+
+use std::collections::{HashMap, VecDeque};
+use std::time::{Duration, Instant};
+
+use crate::app::{AppState, LinkMedium, TargetStat};
+
+/// The one rulebook. The TUI's colour helpers, the triage ladder, and doctor
+/// mode all judge against these, so they can never disagree.
+pub mod thresholds {
+    /// Packet loss that colours yellow / raises a Warn.
+    pub const LOSS_WARN_PCT: f64 = 1.0;
+    /// Packet loss that colours red / raises a finding.
+    pub const LOSS_BAD_PCT: f64 = 5.0;
+    /// Recent loss above this reads as "unresponsive" rather than "degraded".
+    pub const LOSS_DOWN_PCT: f64 = 50.0;
+    pub const RTT_WARN_MS: f64 = 50.0;
+    pub const RTT_BAD_MS: f64 = 150.0;
+    pub const DNS_WARN_MS: f64 = 30.0;
+    pub const DNS_BAD_MS: f64 = 120.0;
+    /// Bufferbloat grade steps (Waveform/Cloudflare scale):
+    /// excellent < 5 ≤ good < 30 ≤ moderate < 60 ≤ poor < 200 ≤ bad.
+    pub const BLOAT_STEPS_MS: [f64; 4] = [5.0, 30.0, 60.0, 200.0];
+    /// Bufferbloat magnitude that earns a finding (the "moderate" step).
+    pub const BLOAT_FINDING_MS: f64 = 60.0;
+    pub const USAGE_WARN_PCT: f32 = 60.0;
+    pub const USAGE_BAD_PCT: f32 = 85.0;
+    pub const RSSI_WEAK_DBM: i32 = -75;
+    pub const RSSI_BAD_DBM: i32 = -82;
+    /// Below this the radio itself is almost certainly the problem.
+    pub const RSSI_AWFUL_DBM: i32 = -85;
+    pub const SNR_MIN_DB: i32 = 15;
+    pub const LINK_ERR_BAD_PCT: f64 = 1.0;
+    pub const CPU_HOT_PCT: f32 = 90.0;
+    pub const CORE_HOT_PCT: f32 = 95.0;
+    pub const MEM_HOT_PCT: f32 = 90.0;
+    /// Outcomes considered for *detection*. The display window (100) takes
+    /// 100 s to reflect an outage; 20 reacts inside half a minute.
+    pub const RECENT: usize = 20;
+    /// Below this many outcomes a probe has no opinion, only noise.
+    pub const MIN_SAMPLES: usize = 5;
+    /// RTT counts as inflated above `max(factor × idle floor, this floor)` —
+    /// the absolute floor keeps a 1 ms → 4 ms gateway from reading as a fault.
+    pub const RTT_INFLATED_FLOOR_MS: f64 = 30.0;
+    pub const RTT_INFLATED_FACTOR: f64 = 3.0;
+    /// A finding raises when present in ≥ RAISE_HITS of the last RAISE_WINDOW
+    /// ticks, and clears after CLEAR_TICKS consecutive quiet ticks.
+    pub const RAISE_HITS: usize = 4;
+    pub const RAISE_WINDOW: usize = 6;
+    pub const CLEAR_TICKS: u32 = 8;
+    /// No verdict at all until this much uptime — early probes are still queued.
+    pub const WARMUP_SECS: u64 = 10;
+}
+use thresholds as th;
+
+/// What is at fault. Declaration order is most-specific-first and doubles as
+/// the ranking tiebreak; the caveat-class causes at the end are co-reported but
+/// never the sole confident answer.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub enum Cause {
+    /// Highest-ranked: nothing else matters until the sign-in page is dealt with.
+    CaptivePortal,
+    GatewayLan,
+    WifiLink,
+    Dns,
+    IspHop,
+    WideInternet,
+    Ipv6Broken,
+    HttpBlocked,
+    WebTarget,
+    SingleDestination,
+    Bufferbloat,
+    Machine,
+    VpnCaveat,
+}
+
+impl Cause {
+    /// Caveat-class findings colour the reading of everything else but must
+    /// never outrank a network cause.
+    pub fn is_caveat(self) -> bool {
+        matches!(self, Cause::Machine | Cause::VpnCaveat)
+    }
+
+    /// Stable slug for the JSON report.
+    pub fn label(self) -> &'static str {
+        match self {
+            Cause::CaptivePortal => "captive-portal",
+            Cause::GatewayLan => "gateway",
+            Cause::WifiLink => "link",
+            Cause::Dns => "dns",
+            Cause::IspHop => "isp",
+            Cause::WideInternet => "internet",
+            Cause::Ipv6Broken => "ipv6",
+            Cause::HttpBlocked => "http-blocked",
+            Cause::WebTarget => "web-target",
+            Cause::SingleDestination => "destination",
+            Cause::Bufferbloat => "bufferbloat",
+            Cause::Machine => "machine",
+            Cause::VpnCaveat => "vpn-caveat",
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+pub enum Severity {
+    Info,
+    Degraded,
+    Down,
+}
+
+impl Severity {
+    pub fn label(self) -> &'static str {
+        match self {
+            Severity::Info => "info",
+            Severity::Degraded => "degraded",
+            Severity::Down => "down",
+        }
+    }
+}
+
+/// "3m 12s" — durations in event messages ("ended after …").
+pub fn fmt_duration(d: Duration) -> String {
+    let secs = d.as_secs();
+    match (secs / 3600, (secs % 3600) / 60, secs % 60) {
+        (0, 0, s) => format!("{s}s"),
+        (0, m, s) => format!("{m}m {s:02}s"),
+        (h, m, _) => format!("{h}h {m:02}m"),
+    }
+}
+
+/// Ordinal wording, deliberately not fake percentages.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+pub enum Confidence {
+    Weak,
+    Likely,
+    Strong,
+}
+
+impl Confidence {
+    pub fn word(self) -> &'static str {
+        match self {
+            Confidence::Weak => "weak",
+            Confidence::Likely => "likely",
+            Confidence::Strong => "strong",
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Finding {
+    pub cause: Cause,
+    pub severity: Severity,
+    pub confidence: Confidence,
+    /// One line: "gateway unresponsive (100% loss)".
+    pub summary: String,
+    /// Supporting data lines for the triage overlay / doctor output.
+    pub evidence: Vec<String>,
+    /// Stable key detail (e.g. a target label) — hysteresis identity is
+    /// `(cause, subject)`, so two bad destinations track independently.
+    pub subject: String,
+}
+
+/// The rank order: severity first, confidence second, specificity third —
+/// except caveat-class causes always sort after network causes.
+fn rank(findings: &mut [Finding]) {
+    findings.sort_by(|a, b| {
+        (a.cause.is_caveat(), b.severity, b.confidence, a.cause, &a.subject).cmp(&(
+            b.cause.is_caveat(),
+            a.severity,
+            a.confidence,
+            b.cause,
+            &b.subject,
+        ))
+    });
+}
+
+/// The headline state the footer renders.
+#[derive(Clone, Debug)]
+pub enum Verdict {
+    /// Not enough data to say anything — never rendered as "healthy".
+    Insufficient(String),
+    Healthy,
+    /// ALL active findings, ranked — never collapsed to one.
+    Problems(Vec<Finding>),
+}
+
+impl Default for Verdict {
+    fn default() -> Self {
+        Verdict::Insufficient("measuring…".to_string())
+    }
+}
+
+/// A subsystem on the triage ladder, in blame order from the machine outward.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Area {
+    Machine,
+    Link,
+    Gateway,
+    Dns,
+    IspPath,
+    Internet,
+    /// HTTP-layer reachability — the internet as a browser sees it.
+    Http,
+    Destinations,
+}
+
+impl Area {
+    pub fn label(self) -> &'static str {
+        match self {
+            Area::Machine => "machine",
+            Area::Link => "link",
+            Area::Gateway => "gateway",
+            Area::Dns => "DNS",
+            Area::IspPath => "ISP path",
+            Area::Internet => "internet",
+            Area::Http => "web (HTTP)",
+            Area::Destinations => "destinations",
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum RungStatus {
+    Ok,
+    Warn,
+    Bad,
+    /// No data — distinct from Ok, because "not measured" must never read as
+    /// "measured and fine".
+    Unknown,
+}
+
+impl RungStatus {
+    pub fn label(self) -> &'static str {
+        match self {
+            RungStatus::Ok => "ok",
+            RungStatus::Warn => "warn",
+            RungStatus::Bad => "bad",
+            RungStatus::Unknown => "unknown",
+        }
+    }
+}
+
+/// One rung of the ladder: a subsystem, its status, and the data behind it —
+/// healthy rungs carry their exonerating evidence.
+#[derive(Clone, Debug)]
+pub struct Rung {
+    pub area: Area,
+    pub status: RungStatus,
+    pub detail: String,
+}
+
+/// The full picture: every rung, always in ladder order, plus ranked findings.
+#[derive(Clone, Default, Debug)]
+pub struct Triage {
+    pub rungs: Vec<Rung>,
+    /// Instantaneous (no hysteresis) — what the rules say *right now*. The
+    /// footer shows the hysteresis-filtered set from [`VerdictState`] instead.
+    pub findings: Vec<Finding>,
+}
+
+/// How healthy one probed target looks right now.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Health {
+    NoData,
+    Good,
+    Warn,
+    Bad,
+}
+
+fn probe_health(t: &TargetStat) -> Health {
+    if t.window.len() < th::MIN_SAMPLES {
+        return Health::NoData;
+    }
+    let loss = t.recent_loss_pct(th::RECENT);
+    if loss >= th::LOSS_BAD_PCT {
+        return Health::Bad;
+    }
+    if loss >= th::LOSS_WARN_PCT || inflated(t) {
+        return Health::Warn;
+    }
+    Health::Good
+}
+
+/// Recent mean RTT well above the all-time idle floor.
+fn inflated(t: &TargetStat) -> bool {
+    match (t.stats(th::RECENT).mean, t.min_ever_ms) {
+        (Some(mean), Some(min)) => {
+            mean > (min * th::RTT_INFLATED_FACTOR).max(th::RTT_INFLATED_FLOOR_MS)
+        }
+        _ => false,
+    }
+}
+
+fn fmt_ms(v: Option<f64>) -> String {
+    v.map(|x| format!("{x:.0}ms")).unwrap_or_else(|| "—".into())
+}
+
+/// The auto-discovered gateway target, matched by address first (labels are
+/// only a convention), falling back to the discovery label.
+fn gateway_target(s: &AppState) -> Option<&TargetStat> {
+    s.targets
+        .iter()
+        .find(|t| t.discovered && t.addr.to_string() == s.netinfo.gateway_ip)
+        .or_else(|| s.targets.iter().find(|t| t.discovered && t.label == "gateway"))
+}
+
+/// Why no verdict can be given yet, or `None` once there is enough to judge.
+pub fn insufficient_reason(s: &AppState) -> Option<String> {
+    if s.icmp_error.is_some() {
+        // A working HTTP probe still proves connectivity the way a browser
+        // experiences it, so ICMP being blocked no longer blinds the verdict.
+        let http_alive = matches!(s.http.v4, crate::app::FamilyProbe::Ok(_))
+            || matches!(s.http.v6, crate::app::FamilyProbe::Ok(_))
+            || matches!(s.http.v4, crate::app::FamilyProbe::Captive(_))
+            || matches!(s.http.v6, crate::app::FamilyProbe::Captive(_));
+        return if http_alive {
+            None
+        } else {
+            Some("ICMP unavailable — cannot measure".to_string())
+        };
+    }
+    let warmed = s.started.elapsed().as_secs() >= th::WARMUP_SECS;
+    let sampled = s
+        .targets
+        .iter()
+        .any(|t| t.window.len() >= th::MIN_SAMPLES);
+    if !warmed || !sampled {
+        return Some("measuring…".to_string());
+    }
+    None
+}
+
+/// Pure, instantaneous read of the whole state. No hysteresis, no I/O — doctor
+/// mode calls it once after a batch observation; the live task calls it every
+/// tick and filters through [`VerdictState`].
+pub fn evaluate(s: &AppState) -> Triage {
+    let gw = gateway_target(s);
+    let gw_health = gw.map(probe_health).unwrap_or(Health::NoData);
+    // Anchors: the user's endpoint targets (defaults: Cloudflare/Google/Quad9).
+    // Discovered mid-path hops are excluded — routers deprioritise ICMP, and a
+    // lossy hop that forwards fine is not a destination problem.
+    let anchors: Vec<&TargetStat> = s.targets.iter().filter(|t| !t.discovered).collect();
+    let with_data: Vec<&TargetStat> = anchors
+        .iter()
+        .copied()
+        .filter(|t| probe_health(t) != Health::NoData)
+        .collect();
+    let bad: Vec<&TargetStat> = with_data
+        .iter()
+        .copied()
+        .filter(|t| probe_health(t) == Health::Bad)
+        .collect();
+    let fine = with_data.len() - bad.len();
+    let gw_fine = matches!(gw_health, Health::Good | Health::Warn);
+    // A baseline with enough healthy minutes behind it turns absolute numbers
+    // into "vs your normal here" — evidence and confidence, never a gate:
+    // absolute thresholds still work on the first visit to a network.
+    let baseline = s.baseline.as_ref().filter(|b| b.established());
+
+    let mut findings: Vec<Finding> = Vec::new();
+
+    // --- gateway / LAN ---
+    if let Some(g) = gw {
+        let loss = g.recent_loss_pct(th::RECENT);
+        let raise = gw_health == Health::Bad || (gw_health != Health::NoData && inflated(g));
+        if raise {
+            let severity = if loss >= th::LOSS_DOWN_PCT {
+                Severity::Down
+            } else {
+                Severity::Degraded
+            };
+            // Corroboration: everything behind a dead gateway fails, so bad
+            // anchors make the story consistent. Fine anchors *contradict* it —
+            // many gateways deprioritise ICMP while forwarding perfectly.
+            let mut confidence = if bad.len() >= 2 {
+                Confidence::Strong
+            } else if fine >= 2 {
+                Confidence::Weak
+            } else {
+                Confidence::Likely
+            };
+            let summary = if loss >= th::LOSS_DOWN_PCT {
+                format!("gateway unresponsive ({loss:.0}% loss)")
+            } else if loss >= th::LOSS_BAD_PCT {
+                format!("gateway losing packets ({loss:.0}% loss)")
+            } else {
+                format!(
+                    "gateway latency inflated ({} vs {} idle)",
+                    fmt_ms(g.stats(th::RECENT).mean),
+                    fmt_ms(g.min_ever_ms)
+                )
+            };
+            let mut evidence = vec![format!(
+                "gateway {}: {:.0}% loss, last {}",
+                g.addr,
+                loss,
+                fmt_ms(g.last_rtt_ms)
+            )];
+            evidence.push(if fine >= 2 && bad.is_empty() {
+                format!("but {fine} anchors reachable — gateway may just deprioritise ICMP")
+            } else {
+                format!("anchors: {} ok, {} failing", fine, bad.len())
+            });
+            // "vs your normal here" — the baseline agreeing hardens the claim.
+            if let Some(b) = baseline
+                && let (Some(cur), Some(normal)) = (g.stats(th::RECENT).mean, b.gateway_ms)
+                && crate::baseline::well_above(cur, normal)
+            {
+                evidence.push(format!(
+                    "gateway {cur:.0}ms vs ~{normal:.0}ms normal at {} ({:.1}×)",
+                    b.display_name(),
+                    cur / normal.max(0.1)
+                ));
+                // Independent corroboration hardens the claim by one level.
+                confidence = match confidence {
+                    Confidence::Weak => Confidence::Likely,
+                    _ => Confidence::Strong,
+                };
+            }
+            findings.push(Finding {
+                cause: Cause::GatewayLan,
+                severity,
+                confidence,
+                summary,
+                evidence,
+                subject: String::new(),
+            });
+        }
+    }
+
+    // --- physical link (Wi-Fi radio / cable errors) ---
+    let err_pct = s.link_errors.error_pct();
+    if s.netinfo.medium == LinkMedium::WiFi && s.signal.present {
+        let rssi = s.signal.rssi_dbm;
+        let low_snr = s
+            .signal
+            .noise_dbm
+            .is_some_and(|noise| rssi - noise < th::SNR_MIN_DB);
+        let weak = rssi <= th::RSSI_BAD_DBM || low_snr;
+        if weak || err_pct > th::LINK_ERR_BAD_PCT {
+            let hurting = !gw_fine && gw_health != Health::NoData;
+            let mut evidence = vec![format!(
+                "rssi {rssi} dBm{}, tx {:.0} Mbps",
+                s.signal
+                    .noise_dbm
+                    .map(|n| format!(" (noise {n}, SNR {})", rssi - n))
+                    .unwrap_or_default(),
+                s.signal.tx_rate_mbps
+            )];
+            if let Some(b) = baseline
+                && let Some(normal) = b.rssi_dbm
+                && (rssi as f64) < normal - 10.0
+            {
+                evidence.push(format!(
+                    "rssi {rssi} dBm vs ~{normal:.0} dBm normal at {}",
+                    b.display_name()
+                ));
+            }
+            if err_pct > th::LINK_ERR_BAD_PCT {
+                evidence.push(format!("interface errors: {err_pct:.1}% of packets"));
+            }
+            findings.push(if hurting {
+                Finding {
+                    cause: Cause::WifiLink,
+                    severity: Severity::Degraded,
+                    confidence: if rssi <= th::RSSI_AWFUL_DBM {
+                        Confidence::Strong
+                    } else {
+                        Confidence::Likely
+                    },
+                    summary: format!("Wi-Fi link is weak (rssi {rssi} dBm)"),
+                    evidence,
+                    subject: String::new(),
+                }
+            } else {
+                Finding {
+                    cause: Cause::WifiLink,
+                    severity: Severity::Info,
+                    confidence: Confidence::Weak,
+                    summary: format!("Wi-Fi signal weak (rssi {rssi} dBm) — not yet hurting"),
+                    evidence,
+                    subject: String::new(),
+                }
+            });
+        }
+    } else if s.netinfo.medium.is_wired() && err_pct > th::LINK_ERR_BAD_PCT {
+        findings.push(Finding {
+            cause: Cause::WifiLink,
+            severity: Severity::Degraded,
+            confidence: Confidence::Likely,
+            summary: format!("link errors ({err_pct:.1}% of packets)"),
+            evidence: vec![format!(
+                "{}: {} rx / {} tx errors — bad cable or duplex mismatch territory",
+                s.link_errors.iface, s.link_errors.rx_err_total, s.link_errors.tx_err_total
+            )],
+            subject: String::new(),
+        });
+    }
+
+    // --- DNS ---
+    let probes: Vec<&crate::app::DnsProbe> = s.dns.iter().filter(|p| p.sent >= 3).collect();
+    if !probes.is_empty() {
+        let failing = |p: &crate::app::DnsProbe| p.fail_pct() >= 50.0;
+        let slow =
+            |p: &crate::app::DnsProbe| p.mean_ms().is_some_and(|m| m > th::DNS_BAD_MS);
+        let n_fail = probes.iter().filter(|p| failing(p)).count();
+        let n_slow = probes.iter().filter(|p| !failing(p) && slow(p)).count();
+        // The anchors-fine contrast is the whole point: ping works, names don't.
+        let confidence = if fine >= 2 {
+            Confidence::Strong
+        } else if bad.len() >= 2 {
+            Confidence::Weak // everything is failing; DNS is a symptom
+        } else {
+            Confidence::Likely
+        };
+        let mut evidence: Vec<String> = probes
+            .iter()
+            .map(|p| {
+                format!(
+                    "resolver {}: mean {}, {:.0}% failed{}",
+                    p.server,
+                    fmt_ms(p.mean_ms()),
+                    p.fail_pct(),
+                    if p.status.is_empty() {
+                        String::new()
+                    } else {
+                        format!(" ({})", p.status)
+                    }
+                )
+            })
+            .collect();
+        if let Some(b) = baseline
+            && let Some(normal) = b.dns_ms
+        {
+            let worst = probes
+                .iter()
+                .filter_map(|p| p.mean_ms())
+                .fold(0.0_f64, f64::max);
+            if worst > normal * 3.0 && worst > th::DNS_WARN_MS {
+                evidence.push(format!(
+                    "DNS {worst:.0}ms vs ~{normal:.0}ms normal at {}",
+                    b.display_name()
+                ));
+            }
+        }
+        // A working HTTP probe *proves* names resolve — it fetched a hostname
+        // through the system resolver. When octomon's own resolver probes fail
+        // anyway (link-local quirks, port-53 filtering on carrier networks),
+        // the honest claim is "probes blocked", not "DNS down".
+        let names_resolve = matches!(s.http.v4, crate::app::FamilyProbe::Ok(_))
+            || matches!(s.http.v6, crate::app::FamilyProbe::Ok(_));
+        if n_fail == probes.len() && names_resolve {
+            let mut evidence = evidence.clone();
+            evidence.push("HTTP check fetched a hostname fine — resolution itself works".into());
+            findings.push(Finding {
+                cause: Cause::Dns,
+                severity: Severity::Info,
+                confidence: Confidence::Weak,
+                summary: "resolver probes blocked on this network — names still resolve"
+                    .to_string(),
+                evidence,
+                subject: String::new(),
+            });
+        } else if n_fail == probes.len() {
+            findings.push(Finding {
+                cause: Cause::Dns,
+                severity: Severity::Down,
+                confidence,
+                summary: format!("DNS not answering (all {} resolvers failing)", probes.len()),
+                evidence,
+                subject: String::new(),
+            });
+        } else if n_fail + n_slow == probes.len() {
+            findings.push(Finding {
+                cause: Cause::Dns,
+                severity: Severity::Degraded,
+                confidence,
+                summary: "DNS slow on every resolver".to_string(),
+                evidence,
+                subject: String::new(),
+            });
+        } else if n_fail > 0 {
+            findings.push(Finding {
+                cause: Cause::Dns,
+                severity: Severity::Info,
+                confidence: Confidence::Weak,
+                summary: format!("{n_fail} of {} DNS resolvers failing — others fine", probes.len()),
+                evidence,
+                subject: String::new(),
+            });
+        }
+    }
+
+    // --- beyond the gateway: wide internet vs a specific destination ---
+    let wide = gw_fine && bad.len() >= 2 && bad.len() * 2 >= with_data.len();
+    if wide {
+        let all_down = bad
+            .iter()
+            .all(|t| t.recent_loss_pct(th::RECENT) >= th::LOSS_DOWN_PCT);
+        let severity = if all_down { Severity::Down } else { Severity::Degraded };
+        let mut evidence: Vec<String> = vec![format!(
+            "gateway fine ({}, {:.0}% loss) but {} of {} anchors failing",
+            fmt_ms(gw.and_then(|g| g.last_rtt_ms)),
+            gw.map(|g| g.recent_loss_pct(th::RECENT)).unwrap_or(0.0),
+            bad.len(),
+            with_data.len()
+        )];
+        for t in &bad {
+            evidence.push(format!(
+                "{} ({}): {:.0}% loss",
+                t.label,
+                t.addr,
+                t.recent_loss_pct(th::RECENT)
+            ));
+        }
+        // Localise with the hop monitor when one is running: loss that begins
+        // within the first few hops is the ISP's segment, not the wide internet.
+        let early_bad_hop = s.hop_monitor.as_ref().and_then(|m| {
+            m.hops.iter().find(|h| {
+                h.ttl >= 2
+                    && h.ttl <= 4
+                    && h.stat.as_ref().is_some_and(|st| {
+                        st.window.len() >= 10 && st.recent_loss_pct(th::RECENT) >= th::LOSS_BAD_PCT
+                    })
+            })
+        });
+        if let Some(h) = early_bad_hop {
+            let addr = h
+                .addr
+                .map(|a| a.to_string())
+                .unwrap_or_else(|| "?".to_string());
+            evidence.push(format!("loss begins at hop {} ({})", h.ttl, addr));
+            findings.push(Finding {
+                cause: Cause::IspHop,
+                severity,
+                confidence: Confidence::Strong,
+                summary: format!("ISP path degraded — loss begins at hop {} ({addr})", h.ttl),
+                evidence,
+                subject: String::new(),
+            });
+        } else {
+            findings.push(Finding {
+                cause: Cause::WideInternet,
+                severity,
+                confidence: Confidence::Strong,
+                summary: format!(
+                    "internet {} beyond the gateway ({} of {} anchors failing)",
+                    if all_down { "unreachable" } else { "degraded" },
+                    bad.len(),
+                    with_data.len()
+                ),
+                evidence,
+                subject: String::new(),
+            });
+        }
+    } else if gw_health != Health::Bad && fine >= 2 {
+        // Consensus says the connection works; whatever is bad is *that* place.
+        for t in &bad {
+            let loss = t.recent_loss_pct(th::RECENT);
+            let what = if loss >= th::LOSS_DOWN_PCT {
+                "unreachable".to_string()
+            } else {
+                format!("degraded ({loss:.0}% loss)")
+            };
+            findings.push(Finding {
+                cause: Cause::SingleDestination,
+                severity: Severity::Degraded,
+                confidence: if bad.len() == 1 {
+                    Confidence::Strong
+                } else {
+                    Confidence::Likely
+                },
+                summary: format!("{} {what} — your connection is fine", t.label),
+                evidence: vec![
+                    format!("{} ({}): {loss:.0}% loss", t.label, t.addr),
+                    format!("{fine} other anchors fine, gateway fine"),
+                ],
+                subject: t.label.clone(),
+            });
+        }
+    }
+
+    // --- HTTP layer: portals, filtered web traffic, broken IPv6 ---
+    {
+        use crate::app::FamilyProbe as FP;
+        let http = &s.http;
+        let captive = [&http.v4, &http.v6]
+            .into_iter()
+            .find_map(|f| match f {
+                FP::Captive(loc) => Some(loc.clone()),
+                _ => None,
+            });
+        if let Some(location) = captive {
+            let mut evidence = vec![format!(
+                "{} connectivity check answered with a sign-in page",
+                http.provider
+            )];
+            if let Some(loc) = location {
+                evidence.push(format!("redirected to {loc}"));
+            }
+            findings.push(Finding {
+                cause: Cause::CaptivePortal,
+                severity: Severity::Down,
+                confidence: Confidence::Strong,
+                summary: "captive portal — open this network's sign-in page".to_string(),
+                evidence,
+                subject: String::new(),
+            });
+        } else if let (FP::Ok(v4_ms), FP::Fail(reason)) = (&http.v4, &http.v6) {
+            findings.push(Finding {
+                cause: Cause::Ipv6Broken,
+                severity: Severity::Degraded,
+                confidence: Confidence::Likely,
+                summary: "IPv6 broken while IPv4 works — pages stall then load".to_string(),
+                evidence: vec![
+                    format!("v6 probe: {reason} · v4 probe: ok {v4_ms:.0}ms"),
+                    "browsers try v6 first and fall back, adding delay to every request"
+                        .to_string(),
+                ],
+                subject: String::new(),
+            });
+        } else if matches!(http.v4, FP::Fail(_))
+            && !matches!(http.v6, FP::Ok(_))
+            && fine >= 2
+        {
+            let reason = match &http.v4 {
+                FP::Fail(r) => r.clone(),
+                _ => String::new(),
+            };
+            findings.push(Finding {
+                cause: Cause::HttpBlocked,
+                severity: Severity::Degraded,
+                confidence: Confidence::Likely,
+                summary: "web traffic blocked while ping works — proxy or firewall".to_string(),
+                evidence: vec![
+                    format!("HTTP probe failed ({reason}) on two independent endpoints"),
+                    format!("{fine} anchors answer ICMP normally"),
+                ],
+                subject: String::new(),
+            });
+        }
+    }
+
+    // --- web targets that answered before and stopped ---
+    // A captive portal intercepts every HTTP request, so per-target web
+    // failures under one are the portal's story, already ranked first.
+    let captive_active = findings.iter().any(|f| f.cause == Cause::CaptivePortal);
+    if !captive_active {
+        for t in s.targets.iter().filter(|t| !t.discovered) {
+            if t.web.status == crate::app::WebStatus::Web
+                && t.web.fails >= 2
+                && matches!(probe_health(t), Health::Good | Health::Warn)
+            {
+                findings.push(Finding {
+                    cause: Cause::WebTarget,
+                    severity: Severity::Degraded,
+                    confidence: if t.web.fails >= 5 {
+                        Confidence::Strong
+                    } else {
+                        Confidence::Likely
+                    },
+                    summary: format!("{} web service not answering — ping still fine", t.label),
+                    evidence: vec![
+                        format!(
+                            "{} HTTP probes unanswered on a target that served HTTP before",
+                            t.web.fails
+                        ),
+                        format!(
+                            "ICMP to {} still healthy ({:.0}% loss) — the service, not the path",
+                            t.addr,
+                            t.recent_loss_pct(th::RECENT)
+                        ),
+                    ],
+                    subject: t.label.clone(),
+                });
+            }
+        }
+    }
+
+    // --- bufferbloat (only meaningful under load) ---
+    let n = s.window_samples().min(60);
+    let loaded = matches!(s.speedtest.status, crate::app::SpeedStatus::Running)
+        || s.netinfo.link_speed_bps.is_some_and(|cap| {
+            (s.throughput.down_bps + s.throughput.up_bps) * 8.0 > 0.3 * cap as f64
+        });
+    if loaded {
+        let worst = anchors
+            .iter()
+            .filter_map(|t| t.bufferbloat_ms(n).map(|b| (b, t.label.clone())))
+            .max_by(|a, b| a.0.total_cmp(&b.0));
+        if let Some((bloat, label)) = worst
+            && bloat >= th::BLOAT_FINDING_MS
+        {
+            findings.push(Finding {
+                cause: Cause::Bufferbloat,
+                severity: Severity::Degraded,
+                confidence: Confidence::Likely,
+                summary: format!("bufferbloat: +{bloat:.0}ms latency under load"),
+                evidence: vec![format!(
+                    "{label}: mean over the last minute is {bloat:.0}ms above the idle floor"
+                )],
+                subject: String::new(),
+            });
+        }
+    }
+
+    // --- machine (caveat-class: co-reported, never the sole confident answer) ---
+    let v = &s.vitals;
+    if v.throttled {
+        findings.push(Finding {
+            cause: Cause::Machine,
+            severity: Severity::Degraded,
+            confidence: Confidence::Strong,
+            summary: "thermal throttling active".to_string(),
+            evidence: vec![
+                "the OS is limiting performance — throughput collapses while CPU reads idle"
+                    .to_string(),
+            ],
+            subject: "thermal".to_string(),
+        });
+    }
+    let hottest = v.hottest_core().map(|(_, pct)| pct).unwrap_or(0.0);
+    if v.cpu_pct >= th::CPU_HOT_PCT || hottest >= th::CORE_HOT_PCT {
+        findings.push(Finding {
+            cause: Cause::Machine,
+            severity: Severity::Info,
+            confidence: Confidence::Likely,
+            summary: format!("machine under load (cpu {:.0}%)", v.cpu_pct),
+            evidence: vec![format!(
+                "cpu {:.0}%, hottest core {hottest:.0}%",
+                v.cpu_pct
+            )],
+            subject: "cpu".to_string(),
+        });
+    }
+    if v.mem_pressure_pct >= th::MEM_HOT_PCT {
+        findings.push(Finding {
+            cause: Cause::Machine,
+            severity: Severity::Info,
+            confidence: Confidence::Likely,
+            summary: format!("memory pressure high ({:.0}%)", v.mem_pressure_pct),
+            evidence: vec![format!(
+                "pressure {:.0}%, swap {} MiB used",
+                v.mem_pressure_pct,
+                v.swap_used / 1_048_576
+            )],
+            subject: "memory".to_string(),
+        });
+    }
+
+    // --- VPN caveat: everything above was measured through the tunnel ---
+    if let Some(vendor) = s.netinfo.tunnel_label()
+        && findings.iter().any(|f| !f.cause.is_caveat())
+    {
+        findings.push(Finding {
+            cause: Cause::VpnCaveat,
+            severity: Severity::Info,
+            confidence: Confidence::Weak,
+            summary: format!("measurements traverse {vendor} — the tunnel may be the cause"),
+            evidence: vec![format!(
+                "default route egresses via {}",
+                s.netinfo.tunnel_iface
+            )],
+            subject: String::new(),
+        });
+    }
+
+    rank(&mut findings);
+    let rungs = build_rungs(s, gw, gw_health, &with_data, &bad, fine);
+    Triage { rungs, findings }
+}
+
+/// The ladder itself: every area, always present, in blame order. Healthy rungs
+/// carry their data — "we checked" is the difference between a verdict and an
+/// assertion.
+fn build_rungs(
+    s: &AppState,
+    gw: Option<&TargetStat>,
+    gw_health: Health,
+    with_data: &[&TargetStat],
+    bad: &[&TargetStat],
+    fine: usize,
+) -> Vec<Rung> {
+    let mut rungs = Vec::with_capacity(7);
+    let health_status = |h: Health| match h {
+        Health::NoData => RungStatus::Unknown,
+        Health::Good => RungStatus::Ok,
+        Health::Warn => RungStatus::Warn,
+        Health::Bad => RungStatus::Bad,
+    };
+
+    // Machine.
+    let v = &s.vitals;
+    let m_status = if v.throttled {
+        RungStatus::Bad
+    } else if v.cpu_pct >= th::USAGE_BAD_PCT || v.mem_pressure_pct >= th::USAGE_BAD_PCT {
+        RungStatus::Warn
+    } else if v.cores.is_empty() {
+        RungStatus::Unknown
+    } else {
+        RungStatus::Ok
+    };
+    rungs.push(Rung {
+        area: Area::Machine,
+        status: m_status,
+        detail: if v.cores.is_empty() {
+            "no data yet".to_string()
+        } else {
+            format!(
+                "cpu {:.0}% · pressure {:.0}%{}",
+                v.cpu_pct,
+                v.mem_pressure_pct,
+                if v.throttled { " · THROTTLED" } else { "" }
+            )
+        },
+    });
+
+    // Physical link.
+    let err_pct = s.link_errors.error_pct();
+    let (l_status, l_detail) = match s.netinfo.medium {
+        LinkMedium::WiFi if s.signal.present => {
+            let rssi = s.signal.rssi_dbm;
+            let status = if rssi <= th::RSSI_BAD_DBM || err_pct > th::LINK_ERR_BAD_PCT {
+                RungStatus::Bad
+            } else if rssi <= th::RSSI_WEAK_DBM {
+                RungStatus::Warn
+            } else {
+                RungStatus::Ok
+            };
+            (
+                status,
+                format!(
+                    "Wi-Fi rssi {rssi} dBm · tx {:.0} Mbps · errors {err_pct:.1}%",
+                    s.signal.tx_rate_mbps
+                ),
+            )
+        }
+        m if m.is_wired() => (
+            if err_pct > th::LINK_ERR_BAD_PCT {
+                RungStatus::Bad
+            } else {
+                RungStatus::Ok
+            },
+            format!(
+                "{}{} · errors {err_pct:.1}%",
+                m.label(),
+                s.netinfo
+                    .link_speed_bps
+                    .map(|b| format!(" {} Mb", b / 1_000_000))
+                    .unwrap_or_default()
+            ),
+        ),
+        LinkMedium::Unknown => (RungStatus::Unknown, "no data yet".to_string()),
+        m => (RungStatus::Ok, m.label().to_string()),
+    };
+    rungs.push(Rung {
+        area: Area::Link,
+        status: l_status,
+        detail: l_detail,
+    });
+
+    // Gateway.
+    rungs.push(match gw {
+        Some(g) if gw_health != Health::NoData => {
+            let st = g.stats(th::RECENT);
+            let mut detail = format!(
+                "{} · p95 {} · loss {:.0}%",
+                g.addr,
+                fmt_ms(st.p95),
+                g.recent_loss_pct(th::RECENT)
+            );
+            if let Some(b) = s.baseline.as_ref().filter(|b| b.established())
+                && let Some(normal) = b.gateway_ms
+            {
+                detail.push_str(&format!(" · ~{normal:.0}ms normal here"));
+            }
+            Rung {
+                area: Area::Gateway,
+                status: health_status(gw_health),
+                detail,
+            }
+        }
+        _ => Rung {
+            area: Area::Gateway,
+            status: RungStatus::Unknown,
+            detail: "not discovered yet".to_string(),
+        },
+    });
+
+    // DNS.
+    let probes: Vec<&crate::app::DnsProbe> = s.dns.iter().filter(|p| p.sent >= 3).collect();
+    rungs.push(if probes.is_empty() {
+        Rung {
+            area: Area::Dns,
+            status: RungStatus::Unknown,
+            detail: "no data yet".to_string(),
+        }
+    } else {
+        let worst_mean = probes
+            .iter()
+            .filter_map(|p| p.mean_ms())
+            .fold(0.0_f64, f64::max);
+        let n_fail = probes.iter().filter(|p| p.fail_pct() >= 50.0).count();
+        let status = if n_fail == probes.len() {
+            RungStatus::Bad
+        } else if n_fail > 0 || worst_mean > th::DNS_BAD_MS {
+            RungStatus::Warn
+        } else {
+            RungStatus::Ok
+        };
+        Rung {
+            area: Area::Dns,
+            status,
+            detail: format!(
+                "{} resolver{} · worst mean {worst_mean:.0}ms{}",
+                probes.len(),
+                if probes.len() == 1 { "" } else { "s" },
+                if n_fail > 0 {
+                    format!(" · {n_fail} failing")
+                } else {
+                    String::new()
+                }
+            ),
+        }
+    });
+
+    // ISP path (first hops beyond the gateway, via the hop monitor when running).
+    let early: Vec<(&crate::app::MonitoredHop, f64)> = s
+        .hop_monitor
+        .as_ref()
+        .map(|m| {
+            m.hops
+                .iter()
+                .filter(|h| h.ttl >= 2 && h.ttl <= 4)
+                .filter_map(|h| {
+                    h.stat
+                        .as_ref()
+                        .filter(|st| st.window.len() >= th::MIN_SAMPLES)
+                        .map(|st| (h, st.recent_loss_pct(th::RECENT)))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    rungs.push(if early.is_empty() {
+        Rung {
+            area: Area::IspPath,
+            status: RungStatus::Unknown,
+            detail: "no path monitor — [m] to watch every hop".to_string(),
+        }
+    } else {
+        let worst = early.iter().map(|(_, l)| *l).fold(0.0_f64, f64::max);
+        let status = if worst >= th::LOSS_BAD_PCT {
+            RungStatus::Bad
+        } else if worst >= th::LOSS_WARN_PCT {
+            RungStatus::Warn
+        } else {
+            RungStatus::Ok
+        };
+        Rung {
+            area: Area::IspPath,
+            status,
+            detail: format!("hops 2-{} · worst loss {worst:.0}%", 2 + early.len() - 1),
+        }
+    });
+
+    // Internet (anchor consensus).
+    rungs.push(if with_data.is_empty() {
+        Rung {
+            area: Area::Internet,
+            status: RungStatus::Unknown,
+            detail: "no data yet".to_string(),
+        }
+    } else {
+        let worst_loss = with_data
+            .iter()
+            .map(|t| t.recent_loss_pct(th::RECENT))
+            .fold(0.0_f64, f64::max);
+        let worst_p95 = with_data
+            .iter()
+            .filter_map(|t| t.stats(th::RECENT).p95)
+            .fold(0.0_f64, f64::max);
+        let status = if bad.len() >= 2 {
+            RungStatus::Bad
+        } else if bad.len() == 1 || worst_loss >= th::LOSS_WARN_PCT {
+            RungStatus::Warn
+        } else {
+            RungStatus::Ok
+        };
+        Rung {
+            area: Area::Internet,
+            status,
+            detail: format!(
+                "{} anchor{} · worst p95 {worst_p95:.0}ms · worst loss {worst_loss:.0}%",
+                with_data.len(),
+                if with_data.len() == 1 { "" } else { "s" }
+            ),
+        }
+    });
+
+    // Web (HTTP layer).
+    rungs.push({
+        use crate::app::FamilyProbe as FP;
+        let describe = |f: &FP, name: &str| match f {
+            FP::NotRun => format!("{name} not probed yet"),
+            FP::NotApplicable => format!("{name} n/a"),
+            FP::Ok(ms) => format!("{name} ok {ms:.0}ms"),
+            FP::Captive(_) => format!("{name} CAPTIVE PORTAL"),
+            FP::Fail(r) => format!("{name} failed ({r})"),
+        };
+        let status = match (&s.http.v4, &s.http.v6) {
+            (FP::Captive(_), _) | (_, FP::Captive(_)) => RungStatus::Bad,
+            (FP::Fail(_), FP::Ok(_)) | (FP::Ok(_), FP::Fail(_)) => RungStatus::Warn,
+            (FP::Fail(_), _) => RungStatus::Bad,
+            (FP::Ok(_), _) => RungStatus::Ok,
+            (FP::NotRun, _) => RungStatus::Unknown,
+            (FP::NotApplicable, _) => RungStatus::Unknown,
+        };
+        let mut detail = format!(
+            "{} · {}",
+            describe(&s.http.v4, "v4"),
+            describe(&s.http.v6, "v6")
+        );
+        if let Some(note) = &s.http.note {
+            detail.push_str(&format!(" · {note}"));
+        }
+        Rung {
+            area: Area::Http,
+            status,
+            detail,
+        }
+    });
+
+    // Destinations: the odd ones out while consensus says the connection works.
+    rungs.push(if with_data.is_empty() {
+        Rung {
+            area: Area::Destinations,
+            status: RungStatus::Unknown,
+            detail: "no data yet".to_string(),
+        }
+    } else if !bad.is_empty() && fine >= 2 && bad.len() * 2 < with_data.len() {
+        let names: Vec<&str> = bad.iter().map(|t| t.label.as_str()).collect();
+        Rung {
+            area: Area::Destinations,
+            status: RungStatus::Bad,
+            detail: format!("struggling: {}", names.join(", ")),
+        }
+    } else {
+        Rung {
+            area: Area::Destinations,
+            status: RungStatus::Ok,
+            detail: "all targets reachable".to_string(),
+        }
+    });
+
+    rungs
+}
+
+/// A finding raise or clear, for the event timeline.
+#[derive(Clone, Debug)]
+pub struct Transition {
+    pub raised: bool,
+    pub finding: Finding,
+    /// How long the finding was active — set on clears.
+    pub after: Option<Duration>,
+}
+
+struct Track {
+    hits: VecDeque<bool>,
+    active: Option<Active>,
+}
+
+struct Active {
+    since: Instant,
+    quiet: u32,
+    last: Finding,
+}
+
+/// Hysteresis over [`evaluate`]'s raw findings, keyed by `(cause, subject)`:
+/// raise on ≥4 of the last 6 ticks, clear after 8 consecutive quiet ticks.
+/// Severity/confidence/evidence of an active finding update live.
+#[derive(Default)]
+pub struct VerdictState {
+    pub current: Verdict,
+    /// Latest full ladder, for the triage overlay.
+    pub triage: Triage,
+    tracker: HashMap<(Cause, String), Track>,
+}
+
+impl VerdictState {
+    /// Fold one tick's evaluation in; returns raise/clear transitions.
+    pub fn ingest(
+        &mut self,
+        triage: Triage,
+        insufficient: Option<String>,
+        now: Instant,
+    ) -> Vec<Transition> {
+        let mut present: HashMap<(Cause, String), Finding> = triage
+            .findings
+            .iter()
+            .map(|f| ((f.cause, f.subject.clone()), f.clone()))
+            .collect();
+        for key in present.keys() {
+            self.tracker.entry(key.clone()).or_insert_with(|| Track {
+                hits: VecDeque::with_capacity(th::RAISE_WINDOW),
+                active: None,
+            });
+        }
+
+        let mut transitions = Vec::new();
+        self.tracker.retain(|key, tr| {
+            let hit = present.remove(key);
+            if tr.hits.len() == th::RAISE_WINDOW {
+                tr.hits.pop_front();
+            }
+            tr.hits.push_back(hit.is_some());
+
+            match (&mut tr.active, hit) {
+                (Some(active), Some(f)) => {
+                    active.quiet = 0;
+                    // A finding getting *worse* while active (degraded → down)
+                    // is worth a timeline entry of its own — otherwise the
+                    // escalation to "gateway unresponsive (100%)" never shows,
+                    // only the initial partial-loss raise.
+                    if f.severity > active.last.severity {
+                        transitions.push(Transition {
+                            raised: true,
+                            finding: f.clone(),
+                            after: None,
+                        });
+                    }
+                    active.last = f;
+                }
+                (Some(active), None) => {
+                    active.quiet += 1;
+                    if active.quiet >= th::CLEAR_TICKS {
+                        transitions.push(Transition {
+                            raised: false,
+                            finding: active.last.clone(),
+                            after: Some(now.duration_since(active.since)),
+                        });
+                        tr.active = None;
+                    }
+                }
+                (None, Some(f)) => {
+                    let hits = tr.hits.iter().filter(|h| **h).count();
+                    if hits >= th::RAISE_HITS {
+                        transitions.push(Transition {
+                            raised: true,
+                            finding: f.clone(),
+                            after: None,
+                        });
+                        tr.active = Some(Active {
+                            since: now,
+                            quiet: 0,
+                            last: f,
+                        });
+                    }
+                }
+                (None, None) => {}
+            }
+            tr.active.is_some() || tr.hits.iter().any(|h| *h)
+        });
+
+        let mut active: Vec<Finding> = self
+            .tracker
+            .values()
+            .filter_map(|t| t.active.as_ref().map(|a| a.last.clone()))
+            .collect();
+        rank(&mut active);
+
+        self.current = match insufficient {
+            Some(reason) => Verdict::Insufficient(reason),
+            None if active.is_empty() => Verdict::Healthy,
+            None => Verdict::Problems(active),
+        };
+        self.triage = triage;
+        transitions
+    }
+
+}
+
+/// The triage ladder + findings as plain text — doctor mode's `== VERDICT ==`
+/// section, the same shape as the [y] overlay so TUI and doctor can never
+/// disagree.
+pub fn render_text(triage: &Triage, insufficient: Option<&str>) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::new();
+    let _ = writeln!(out, "== ANALYSIS ==");
+    for r in &triage.rungs {
+        let glyph = match r.status {
+            RungStatus::Ok => "✓",
+            RungStatus::Warn => "~",
+            RungStatus::Bad => "✗",
+            RungStatus::Unknown => "?",
+        };
+        let _ = writeln!(out, "  {glyph} {:<13} {}", r.area.label(), r.detail);
+    }
+    let _ = writeln!(out);
+    if let Some(reason) = insufficient {
+        let _ = writeln!(out, "  {reason}");
+    } else if triage.findings.is_empty() {
+        let _ = writeln!(out, "  no findings — connection looks healthy");
+    } else {
+        for f in &triage.findings {
+            let _ = writeln!(out, "  ▲ {}", f.summary);
+            for e in &f.evidence {
+                let _ = writeln!(out, "      {e}");
+            }
+        }
+    }
+    out
+}
+
+/// Script-friendly exit code: 0 healthy · 1 anything ≥ Degraded (severity, not
+/// confidence, drives it) · 3 could not measure. 2 is deliberately skipped —
+/// clap and the bad-target path already exit 2 for usage errors, and scripts
+/// must be able to tell "bad invocation" from "network is down".
+pub fn exit_code(triage: &Triage, insufficient: bool) -> i32 {
+    if insufficient {
+        return 3;
+    }
+    if triage
+        .findings
+        .iter()
+        .any(|f| f.severity >= Severity::Degraded)
+    {
+        1
+    } else {
+        0
+    }
+}
+
+/// Disk work decided under the lock, executed off it.
+enum BaselineIo {
+    None,
+    /// The network changed: load (or create) its baseline.
+    Load { key: String, label: String },
+    /// A healthy minute was folded in: persist.
+    Save {
+        key: String,
+        baseline: crate::baseline::Baseline,
+    },
+}
+
+/// Collector task: re-evaluate every sample interval, writing the verdict and
+/// triage ladder back into shared state. Finding raises and clears land on the
+/// event timeline — this is where "loss spike started / ended" comes from.
+/// Also owns the baseline lifecycle: it already wakes every second and knows
+/// whether the verdict is Healthy, which is the anti-poisoning gate.
+pub async fn run(state: std::sync::Arc<std::sync::Mutex<AppState>>, cfg: crate::config::Config) {
+    let mut tick = tokio::time::interval(cfg.sample_interval());
+    // Consecutive fully-healthy ticks; a fold happens each time this hits 60.
+    let mut healthy_run: u32 = 0;
+    let mut last_speed_total: Option<usize> = None;
+    loop {
+        tick.tick().await;
+        let now = Instant::now();
+
+        let io = {
+            let mut s = state.lock().unwrap();
+            let triage = evaluate(&s);
+            let insufficient = insufficient_reason(&s);
+            for t in s.verdict.ingest(triage, insufficient, now) {
+                let (severity, message) = if t.raised {
+                    (t.finding.severity, format!("▲ {}", t.finding.summary))
+                } else {
+                    // Clears are good news: Info regardless of how bad it was.
+                    (
+                        Severity::Info,
+                        format!(
+                            "✓ {} — ended after {}",
+                            t.finding.summary,
+                            fmt_duration(t.after.unwrap_or_default())
+                        ),
+                    )
+                };
+                s.push_event(severity, crate::app::EventCategory::Analysis, message);
+            }
+
+            baseline_step(&mut s, &mut healthy_run, &mut last_speed_total)
+        };
+
+        // File I/O strictly off the lock.
+        match io {
+            BaselineIo::None => {}
+            BaselineIo::Load { key, label } => {
+                let loaded = tokio::task::spawn_blocking({
+                    let key = key.clone();
+                    move || crate::baseline::load_one(&key)
+                })
+                .await
+                .ok()
+                .flatten();
+                let mut s = state.lock().unwrap();
+                // The network may have moved again while we read the file.
+                if crate::baseline::fingerprint(&s.netinfo).map(|f| f.0) == Some(key.clone()) {
+                    s.baseline = Some(loaded.unwrap_or(crate::baseline::Baseline {
+                        label,
+                        ..Default::default()
+                    }));
+                    s.baseline_key = Some(key);
+                }
+            }
+            BaselineIo::Save { key, baseline } => {
+                let _ = tokio::task::spawn_blocking(move || {
+                    crate::baseline::save_one(&key, &baseline)
+                })
+                .await;
+            }
+        }
+    }
+}
+
+/// One tick of baseline bookkeeping. Decides what disk work is needed; does
+/// none of it here (the caller holds the state lock).
+fn baseline_step(
+    s: &mut AppState,
+    healthy_run: &mut u32,
+    last_speed_total: &mut Option<usize>,
+) -> BaselineIo {
+    // Network fingerprint changed (or never resolved): swap baselines.
+    let fp = crate::baseline::fingerprint(&s.netinfo);
+    match &fp {
+        None => {
+            if s.baseline_key.is_some() {
+                s.baseline_key = None;
+                s.baseline = None;
+            }
+            *healthy_run = 0;
+            return BaselineIo::None;
+        }
+        Some((key, label)) if s.baseline_key.as_deref() != Some(key.as_str()) => {
+            *healthy_run = 0;
+            *last_speed_total = Some(s.speed_total);
+            return BaselineIo::Load {
+                key: key.clone(),
+                label: label.clone(),
+            };
+        }
+        Some(_) => {}
+    }
+
+    let Some(key) = s.baseline_key.clone() else {
+        return BaselineIo::None;
+    };
+    let mut changed = false;
+
+    // A completed speed test overwrites the expected throughput — speed tests
+    // are rare enough that an EWMA would never converge. Deliberate user
+    // action, so a softer gate than the fold: only a Degraded-or-worse finding
+    // (which would genuinely skew a capacity reading) blocks it.
+    let new_speedtest = *last_speed_total != Some(s.speed_total);
+    if new_speedtest {
+        *last_speed_total = Some(s.speed_total);
+        let severe = match &s.verdict.current {
+            Verdict::Problems(f) => f.iter().any(|x| x.severity >= Severity::Degraded),
+            Verdict::Insufficient(_) => true,
+            Verdict::Healthy => false,
+        };
+        if !severe
+            && let (Some(d), Some(u)) = (s.speedtest.down_mbps, s.speedtest.up_mbps)
+            && let Some(b) = s.baseline.as_mut()
+        {
+            b.down_mbps = Some(d);
+            b.up_mbps = Some(u);
+            changed = true;
+        }
+    }
+
+    // The fold gate: only a *fully* healthy verdict — any active finding, even
+    // an Info note, skips the update. An incident must never teach the baseline.
+    let fully_healthy = matches!(s.verdict.current, Verdict::Healthy);
+    if !fully_healthy {
+        *healthy_run = 0;
+    } else {
+        *healthy_run += 1;
+        let uptime_ok = s.started.elapsed().as_secs() > 120;
+        if *healthy_run >= 60 && uptime_ok {
+            *healthy_run = 0;
+            let sample = crate::baseline::Sample::take(s);
+            if let Some(b) = s.baseline.as_mut() {
+                b.fold(sample);
+                changed = true;
+            }
+        }
+    }
+
+    match (changed, s.baseline.clone()) {
+        (true, Some(baseline)) => BaselineIo::Save { key, baseline },
+        _ => BaselineIo::None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{IpAddr, Ipv4Addr};
+
+    /// A target with `ok` replies (10 ms) followed by `lost` timeouts, so the
+    /// *recent* outcomes are the losses.
+    fn probe(label: &str, addr: [u8; 4], ok: usize, lost: usize) -> TargetStat {
+        let mut t = TargetStat::new(label.into(), IpAddr::V4(Ipv4Addr::from(addr)));
+        for _ in 0..ok {
+            t.record_reply(10.0);
+        }
+        for _ in 0..lost {
+            t.record_loss();
+        }
+        t
+    }
+
+    /// Three healthy anchors, a healthy discovered gateway, an idle machine.
+    fn healthy_state() -> AppState {
+        let mut s = AppState::new(vec![
+            probe("Cloudflare", [1, 1, 1, 1], 20, 0),
+            probe("Google", [8, 8, 8, 8], 20, 0),
+            probe("Quad9", [9, 9, 9, 9], 20, 0),
+        ]);
+        let mut gw = probe("gateway", [192, 168, 1, 1], 20, 0);
+        gw.discovered = true;
+        s.targets.push(gw);
+        s.netinfo.gateway_ip = "192.168.1.1".into();
+        s.vitals.cores = vec![10.0; 8];
+        s.vitals.cpu_pct = 12.0;
+        s
+    }
+
+    fn causes(t: &Triage) -> Vec<Cause> {
+        t.findings.iter().map(|f| f.cause).collect()
+    }
+
+    #[test]
+    fn healthy_state_yields_no_findings_and_a_full_ladder() {
+        let t = evaluate(&healthy_state());
+        assert!(t.findings.is_empty(), "unexpected: {:?}", t.findings);
+
+        // Every area, always, in ladder order — an absent rung would let
+        // "not measured" masquerade as "fine".
+        let areas: Vec<Area> = t.rungs.iter().map(|r| r.area).collect();
+        assert_eq!(
+            areas,
+            vec![
+                Area::Machine,
+                Area::Link,
+                Area::Gateway,
+                Area::Dns,
+                Area::IspPath,
+                Area::Internet,
+                Area::Http,
+                Area::Destinations
+            ]
+        );
+        let rung = |a: Area| t.rungs.iter().find(|r| r.area == a).unwrap();
+        assert_eq!(rung(Area::Gateway).status, RungStatus::Ok);
+        assert_eq!(rung(Area::Internet).status, RungStatus::Ok);
+        assert_eq!(rung(Area::Machine).status, RungStatus::Ok);
+        // No hop monitor running: unknown, not silently fine.
+        assert_eq!(rung(Area::IspPath).status, RungStatus::Unknown);
+    }
+
+    #[test]
+    fn dead_gateway_with_dead_anchors_is_a_strong_gateway_verdict() {
+        let mut s = healthy_state();
+        for t in &mut s.targets {
+            for _ in 0..15 {
+                t.record_loss();
+            }
+        }
+        let t = evaluate(&s);
+        let f = &t.findings[0];
+        assert_eq!(f.cause, Cause::GatewayLan);
+        assert_eq!(f.severity, Severity::Down);
+        // Everything behind a dead gateway fails: a consistent story.
+        assert_eq!(f.confidence, Confidence::Strong);
+    }
+
+    #[test]
+    fn lossy_gateway_with_fine_anchors_is_only_a_weak_claim() {
+        let mut s = healthy_state();
+        let gw = s.targets.iter_mut().find(|t| t.discovered).unwrap();
+        for _ in 0..15 {
+            gw.record_loss();
+        }
+        let t = evaluate(&s);
+        let f = t
+            .findings
+            .iter()
+            .find(|f| f.cause == Cause::GatewayLan)
+            .unwrap();
+        // The internet is reachable *through* this "dead" gateway — it is
+        // probably just deprioritising ICMP, and the verdict must not shout.
+        assert_eq!(f.confidence, Confidence::Weak);
+        assert!(f.evidence.iter().any(|e| e.contains("deprioritise")));
+    }
+
+    #[test]
+    fn gateway_fine_but_anchors_dead_blames_the_internet() {
+        let mut s = healthy_state();
+        for t in s.targets.iter_mut().filter(|t| !t.discovered).take(2) {
+            for _ in 0..15 {
+                t.record_loss();
+            }
+        }
+        let t = evaluate(&s);
+        let f = &t.findings[0];
+        assert_eq!(f.cause, Cause::WideInternet);
+        assert_eq!(f.severity, Severity::Down);
+        assert_eq!(f.confidence, Confidence::Strong);
+        assert!(!causes(&t).contains(&Cause::SingleDestination));
+    }
+
+    #[test]
+    fn one_dead_target_amid_consensus_blames_that_destination() {
+        let mut s = healthy_state();
+        s.targets.push(probe("myserver", [203, 0, 113, 9], 5, 15));
+        let t = evaluate(&s);
+        let f = &t.findings[0];
+        assert_eq!(f.cause, Cause::SingleDestination);
+        assert_eq!(f.confidence, Confidence::Strong);
+        assert_eq!(f.subject, "myserver");
+        assert!(f.summary.contains("your connection is fine"));
+        assert!(!causes(&t).contains(&Cause::WideInternet));
+    }
+
+    #[test]
+    fn dns_failing_while_ping_works_is_a_strong_dns_verdict() {
+        let mut s = healthy_state();
+        let mut p = crate::app::DnsProbe::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)));
+        p.sent = 10;
+        p.ok = 0;
+        p.status = "timeout".into();
+        s.dns = vec![p];
+        let t = evaluate(&s);
+        let f = &t.findings[0];
+        assert_eq!(f.cause, Cause::Dns);
+        assert_eq!(f.severity, Severity::Down);
+        // The anchors-fine contrast is the whole point.
+        assert_eq!(f.confidence, Confidence::Strong);
+    }
+
+    /// The hotspot lesson: a carrier network handed out a link-local resolver
+    /// octomon couldn't probe, while resolution worked fine. Working HTTP
+    /// (which resolved a hostname) must cap the DNS claim at an Info note.
+    #[test]
+    fn dns_probe_failures_defer_to_a_working_http_check() {
+        let mut s = healthy_state();
+        let mut p = crate::app::DnsProbe::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)));
+        p.sent = 10;
+        p.ok = 0;
+        p.status = "No route to host".into();
+        s.dns = vec![p];
+        s.http.v4 = crate::app::FamilyProbe::Ok(30.0);
+
+        let t = evaluate(&s);
+        let f = t.findings.iter().find(|f| f.cause == Cause::Dns).unwrap();
+        assert_eq!(f.severity, Severity::Info, "not a Down claim: {}", f.summary);
+        assert!(f.summary.contains("names still resolve"));
+        assert!(f.evidence.iter().any(|e| e.contains("HTTP check")));
+    }
+
+    #[test]
+    fn a_web_server_that_stops_answering_is_a_finding_only_if_it_served_before() {
+        use crate::app::WebStatus;
+        let mut s = healthy_state();
+        s.targets.push({
+            let mut t = probe("bbc.co.uk", [151, 101, 0, 81], 20, 0);
+            t.hostname = Some("bbc.co.uk".into());
+            t.web.status = WebStatus::Web;
+            t.web.fails = 3;
+            t
+        });
+        let t = evaluate(&s);
+        let f = t.findings.iter().find(|f| f.cause == Cause::WebTarget).unwrap();
+        assert_eq!(f.subject, "bbc.co.uk");
+        assert!(f.summary.contains("ping still fine"));
+
+        // A target that never served HTTP is never judged on it.
+        let mut s = healthy_state();
+        s.targets.push({
+            let mut t = probe("Quad9", [9, 9, 9, 10], 20, 0);
+            t.web.status = WebStatus::NoService;
+            t
+        });
+        assert!(!causes(&evaluate(&s)).contains(&Cause::WebTarget));
+
+        // And under a captive portal the portal owns the story.
+        let mut s = healthy_state();
+        s.http.v4 = crate::app::FamilyProbe::Captive(None);
+        s.targets.push({
+            let mut t = probe("bbc.co.uk", [151, 101, 0, 81], 20, 0);
+            t.web.status = WebStatus::Web;
+            t.web.fails = 5;
+            t
+        });
+        let c = causes(&evaluate(&s));
+        assert!(c.contains(&Cause::CaptivePortal));
+        assert!(!c.contains(&Cause::WebTarget));
+    }
+
+    /// The mandatory wrongness test: simultaneous causes must BOTH be reported,
+    /// with the network cause ranked above the machine caveat.
+    #[test]
+    fn cpu_spike_never_hides_a_dead_gateway() {
+        let mut s = healthy_state();
+        s.vitals.cpu_pct = 97.0;
+        s.vitals.cores = vec![97.0; 8];
+        for t in &mut s.targets {
+            for _ in 0..15 {
+                t.record_loss();
+            }
+        }
+        let t = evaluate(&s);
+        let c = causes(&t);
+        assert_eq!(c[0], Cause::GatewayLan, "network cause must rank first");
+        assert!(c.contains(&Cause::Machine), "but the CPU is still reported");
+    }
+
+    /// Even a *severe* machine finding stays behind network causes: throttling
+    /// is Degraded like the gateway here, and only the caveat rule breaks the tie.
+    #[test]
+    fn caveat_class_never_outranks_a_network_cause() {
+        let mut s = healthy_state();
+        s.vitals.throttled = true;
+        let gw = s.targets.iter_mut().find(|t| t.discovered).unwrap();
+        for _ in 0..3 {
+            gw.record_loss(); // ~13% recent loss: Degraded, same tier as throttling
+        }
+        let t = evaluate(&s);
+        assert_eq!(causes(&t)[0], Cause::GatewayLan);
+        assert!(causes(&t).contains(&Cause::Machine));
+    }
+
+    #[test]
+    fn vpn_caveat_rides_along_with_any_network_finding() {
+        let mut s = healthy_state();
+        s.netinfo.tunnel = Some("Cloudflare WARP".into());
+        s.netinfo.tunnel_iface = "utun0".into();
+        for t in s.targets.iter_mut().filter(|t| !t.discovered) {
+            for _ in 0..15 {
+                t.record_loss();
+            }
+        }
+        let t = evaluate(&s);
+        let last = t.findings.last().unwrap();
+        assert_eq!(last.cause, Cause::VpnCaveat);
+        assert!(last.summary.contains("Cloudflare WARP"));
+
+        // ...but not on a healthy connection — a VPN is not a finding by itself.
+        let mut h = healthy_state();
+        h.netinfo.tunnel = Some("Tailscale".into());
+        assert!(evaluate(&h).findings.is_empty());
+    }
+
+    #[test]
+    fn a_captive_portal_outranks_everything() {
+        use crate::app::FamilyProbe;
+        let mut s = healthy_state();
+        // Portal blocks everything: pings dead AND http intercepted.
+        for t in &mut s.targets {
+            for _ in 0..15 {
+                t.record_loss();
+            }
+        }
+        s.http.provider = "Apple".into();
+        s.http.v4 = FamilyProbe::Captive(Some("http://portal.cafe/login".into()));
+        s.http.v6 = FamilyProbe::NotApplicable;
+        let t = evaluate(&s);
+        let f = &t.findings[0];
+        assert_eq!(f.cause, Cause::CaptivePortal, "sign-in page first: {:?}", causes(&t));
+        assert_eq!(f.severity, Severity::Down);
+        assert!(f.evidence.iter().any(|e| e.contains("portal.cafe")));
+    }
+
+    #[test]
+    fn broken_v6_with_working_v4_is_named() {
+        use crate::app::FamilyProbe;
+        let mut s = healthy_state();
+        s.http.v4 = FamilyProbe::Ok(38.0);
+        s.http.v6 = FamilyProbe::Fail("timeout".into());
+        let t = evaluate(&s);
+        let f = &t.findings[0];
+        assert_eq!(f.cause, Cause::Ipv6Broken);
+        assert!(f.evidence[0].contains("timeout"));
+
+        // A v4-only LAN must never produce this finding.
+        let mut s = healthy_state();
+        s.http.v4 = FamilyProbe::Ok(38.0);
+        s.http.v6 = FamilyProbe::NotApplicable;
+        assert!(evaluate(&s).findings.is_empty());
+    }
+
+    #[test]
+    fn http_dead_while_ping_works_blames_a_proxy_or_firewall() {
+        use crate::app::FamilyProbe;
+        let mut s = healthy_state();
+        s.http.v4 = FamilyProbe::Fail("connect failed".into());
+        s.http.v6 = FamilyProbe::NotApplicable;
+        let t = evaluate(&s);
+        assert_eq!(t.findings[0].cause, Cause::HttpBlocked);
+
+        // With the anchors ALSO dead there is no ping/http contrast — the
+        // gateway/internet findings own that story instead.
+        let mut s = healthy_state();
+        s.http.v4 = FamilyProbe::Fail("connect failed".into());
+        for t in s.targets.iter_mut().filter(|t| !t.discovered) {
+            for _ in 0..15 {
+                t.record_loss();
+            }
+        }
+        assert!(!causes(&evaluate(&s)).contains(&Cause::HttpBlocked));
+    }
+
+    #[test]
+    fn a_working_http_probe_unblinds_a_no_icmp_verdict() {
+        use crate::app::FamilyProbe;
+        let mut s = AppState::new(vec![]);
+        s.icmp_error = Some("nope".into());
+        assert!(insufficient_reason(&s).is_some());
+        s.http.v4 = FamilyProbe::Ok(30.0);
+        assert!(
+            insufficient_reason(&s).is_none(),
+            "HTTP proves connectivity when ICMP cannot"
+        );
+    }
+
+    #[test]
+    fn baseline_turns_absolute_numbers_into_vs_normal() {
+        let mut s = healthy_state();
+        // Gateway idle floor 5ms, now sitting at 45ms — inflated in absolute
+        // terms AND way above this network's learned normal.
+        let gw = s.targets.iter_mut().find(|t| t.discovered).unwrap();
+        gw.reset();
+        for _ in 0..5 {
+            gw.record_reply(5.0);
+        }
+        for _ in 0..20 {
+            gw.record_reply(45.0);
+        }
+        s.baseline = Some(crate::baseline::Baseline {
+            label: "HomeNet".into(),
+            name: Some("Home".into()),
+            samples: 10,
+            gateway_ms: Some(9.0),
+            ..Default::default()
+        });
+        let t = evaluate(&s);
+        let f = t
+            .findings
+            .iter()
+            .find(|f| f.cause == Cause::GatewayLan)
+            .expect("inflated gateway raises");
+        assert!(
+            f.evidence.iter().any(|e| e.contains("~9ms normal at Home")),
+            "evidence names the location: {:?}",
+            f.evidence
+        );
+        // Anchors are fine (contradiction → Weak), but the baseline agreeing
+        // it is abnormal hardens that by one level.
+        assert_eq!(f.confidence, Confidence::Likely);
+
+        // An unestablished baseline (too few samples) stays silent.
+        s.baseline.as_mut().unwrap().samples = 2;
+        let t = evaluate(&s);
+        let f = t
+            .findings
+            .iter()
+            .find(|f| f.cause == Cause::GatewayLan)
+            .unwrap();
+        assert!(!f.evidence.iter().any(|e| e.contains("normal at")));
+    }
+
+    /// The anti-poisoning rule: an active finding — even a caveat — means the
+    /// baseline learns nothing this minute.
+    #[test]
+    fn incidents_never_teach_the_baseline() {
+        let mut s = healthy_state();
+        if let Some(earlier) = Instant::now().checked_sub(Duration::from_secs(300)) {
+            s.started = earlier;
+        }
+        let (key, label) = crate::baseline::fingerprint(&s.netinfo).expect("fingerprintable");
+        s.baseline_key = Some(key);
+        s.baseline = Some(crate::baseline::Baseline {
+            label,
+            ..Default::default()
+        });
+        s.verdict.current = Verdict::Healthy;
+
+        let mut healthy_run = 59;
+        let mut last_speed = Some(0);
+        let io = baseline_step(&mut s, &mut healthy_run, &mut last_speed);
+        assert!(matches!(io, BaselineIo::Save { .. }), "60th healthy tick folds");
+        assert_eq!(s.baseline.as_ref().unwrap().samples, 1);
+
+        // Now a finding is active: the fold that was one tick away is denied
+        // and the healthy streak starts over.
+        s.verdict.current = Verdict::Problems(vec![fake(Cause::GatewayLan)]);
+        healthy_run = 59;
+        let io = baseline_step(&mut s, &mut healthy_run, &mut last_speed);
+        assert!(matches!(io, BaselineIo::None));
+        assert_eq!(healthy_run, 0, "the streak resets");
+        assert_eq!(s.baseline.as_ref().unwrap().samples, 1, "nothing learned");
+    }
+
+    #[test]
+    fn insufficient_until_warmed_up_and_sampled() {
+        let s = AppState::new(vec![]);
+        assert!(insufficient_reason(&s).is_some(), "no samples yet");
+
+        let mut s = healthy_state();
+        assert!(insufficient_reason(&s).is_some(), "not warmed up yet");
+        if let Some(earlier) = Instant::now().checked_sub(Duration::from_secs(60)) {
+            s.started = earlier;
+            assert!(insufficient_reason(&s).is_none());
+        }
+
+        s.icmp_error = Some("nope".into());
+        let reason = insufficient_reason(&s).expect("no ICMP means no verdict");
+        assert!(reason.contains("ICMP"));
+    }
+
+    fn fake(cause: Cause) -> Finding {
+        Finding {
+            cause,
+            severity: Severity::Degraded,
+            confidence: Confidence::Likely,
+            summary: "x".into(),
+            evidence: vec![],
+            subject: String::new(),
+        }
+    }
+
+    #[test]
+    fn findings_raise_on_four_of_six_ticks_and_clear_after_eight_quiet() {
+        let mut vs = VerdictState::default();
+        let now = Instant::now();
+        let with = Triage {
+            rungs: vec![],
+            findings: vec![fake(Cause::GatewayLan)],
+        };
+        let without = Triage::default();
+
+        for _ in 0..3 {
+            vs.ingest(with.clone(), None, now);
+            assert!(
+                matches!(vs.current, Verdict::Healthy),
+                "3 hits must not raise"
+            );
+        }
+        let transitions = vs.ingest(with.clone(), None, now);
+        assert!(matches!(vs.current, Verdict::Problems(_)), "4th hit raises");
+        assert!(transitions.iter().any(|t| t.raised));
+
+        for i in 0..7 {
+            vs.ingest(without.clone(), None, now);
+            assert!(
+                matches!(vs.current, Verdict::Problems(_)),
+                "still active after {} quiet ticks",
+                i + 1
+            );
+        }
+        let transitions = vs.ingest(without.clone(), None, now);
+        assert!(matches!(vs.current, Verdict::Healthy), "8th quiet tick clears");
+        let cleared = transitions.iter().find(|t| !t.raised).unwrap();
+        assert!(cleared.after.is_some(), "clears carry the active duration");
+    }
+
+    /// The bug from live testing: Wi-Fi off showed "25% loss" on the timeline
+    /// but never the escalation to "unresponsive (100%)" — an active finding
+    /// getting worse must land as its own transition.
+    #[test]
+    fn severity_escalation_of_an_active_finding_is_a_new_transition() {
+        let mut vs = VerdictState::default();
+        let now = Instant::now();
+        let degraded = Triage {
+            rungs: vec![],
+            findings: vec![fake(Cause::GatewayLan)],
+        };
+        for _ in 0..4 {
+            vs.ingest(degraded.clone(), None, now);
+        }
+        assert!(matches!(vs.current, Verdict::Problems(_)));
+
+        let mut worse = fake(Cause::GatewayLan);
+        worse.severity = Severity::Down;
+        worse.summary = "gateway unresponsive (100% loss)".into();
+        let t = vs.ingest(
+            Triage {
+                rungs: vec![],
+                findings: vec![worse.clone()],
+            },
+            None,
+            now,
+        );
+        let esc = t.iter().find(|t| t.raised).expect("escalation transition");
+        assert_eq!(esc.finding.severity, Severity::Down);
+        assert!(esc.finding.summary.contains("100%"));
+
+        // Same severity again: no repeat spam.
+        let t = vs.ingest(
+            Triage {
+                rungs: vec![],
+                findings: vec![worse],
+            },
+            None,
+            now,
+        );
+        assert!(t.is_empty());
+    }
+
+    #[test]
+    fn a_single_blip_never_raises() {
+        let mut vs = VerdictState::default();
+        let now = Instant::now();
+        let with = Triage {
+            rungs: vec![],
+            findings: vec![fake(Cause::WideInternet)],
+        };
+        for _ in 0..3 {
+            vs.ingest(with.clone(), None, now);
+            for _ in 0..6 {
+                vs.ingest(Triage::default(), None, now);
+            }
+        }
+        assert!(matches!(vs.current, Verdict::Healthy));
+    }
+
+    #[test]
+    fn render_text_carries_the_ladder_and_the_evidence() {
+        let mut s = healthy_state();
+        let out = render_text(&evaluate(&s), None);
+        assert!(out.starts_with("== ANALYSIS =="));
+        assert!(out.contains("✓ gateway"));
+        assert!(out.contains("? ISP path"), "unmeasured stays a question mark");
+        assert!(out.contains("no findings"));
+
+        for t in &mut s.targets {
+            for _ in 0..15 {
+                t.record_loss();
+            }
+        }
+        let out = render_text(&evaluate(&s), None);
+        assert!(out.contains("▲ gateway unresponsive"));
+        // Confidence words stay internal; the evidence makes the case.
+        assert!(!out.contains("— strong"));
+        assert!(out.contains("% loss, last"), "evidence lines included");
+
+        let out = render_text(&Triage::default(), Some("ICMP unavailable — cannot measure"));
+        assert!(out.contains("ICMP unavailable"));
+    }
+
+    #[test]
+    fn exit_codes_separate_healthy_broken_and_unmeasurable() {
+        let healthy = evaluate(&healthy_state());
+        assert_eq!(exit_code(&healthy, false), 0);
+        assert_eq!(exit_code(&healthy, true), 3, "insufficient wins");
+
+        let mut s = healthy_state();
+        for t in &mut s.targets {
+            for _ in 0..15 {
+                t.record_loss();
+            }
+        }
+        assert_eq!(exit_code(&evaluate(&s), false), 1);
+
+        // Info-class notes (busy CPU) are not failures.
+        let mut s = healthy_state();
+        s.vitals.cpu_pct = 97.0;
+        s.vitals.cores = vec![97.0; 8];
+        let t = evaluate(&s);
+        assert!(!t.findings.is_empty());
+        assert_eq!(exit_code(&t, false), 0);
+    }
+
+    #[test]
+    fn insufficient_overrides_everything() {
+        let mut vs = VerdictState::default();
+        let now = Instant::now();
+        let out = vs.ingest(Triage::default(), Some("measuring…".into()), now);
+        assert!(out.is_empty());
+        assert!(matches!(vs.current, Verdict::Insufficient(_)));
+    }
+}


### PR DESCRIPTION
## What this is

octomon now answers its own question — "is it my machine, my local network, my ISP, or the internet?" — instead of only showing the evidence.

- **Live analysis line** (footer): one synthesized headline, never bluffing — press `y` for the triage ladder showing every subsystem (machine → link → gateway → DNS → ISP path → internet → web → destinations) with status *and* data, healthy rungs included. Findings are hysteresis-filtered, ranked, all-reported (a busy CPU can never hide a dead gateway), with machine/VPN treated as caveats.
- **Per-network baselines**: learned per location fingerprint (SSID + gateway MAC; SSID-only for gatewayless hotspots), only from healthy minutes. Name with `N`, browse all with `L`. Analysis reads "gateway 41ms vs ~9ms normal at Home".
- **Event timeline** (`e`): finding raises/clears with durations and escalations, network/SSID/DNS/VPN changes, link lost/restored (auto stat reset), speed tests. Drains into CSV recordings.
- **HTTP, two layers**: internet-level check (OS-native endpoint, second-opinion verification; captive portal / broken-IPv6 / web-filtered findings) in the Network panel — and per-target web probing with a TTFB strip in Connection Quality, where refused / filtered / never-served are honestly distinguished.
- **Hostname targets**: names stay names — HTTPS with SNI, re-resolved on network change (CDN answers are per-location) with a timeline entry when the answer moves.
- **ICMPv6 + hotspot fixes**: per-family ping clients (v6-resolved targets work on v6-only carriers), link-local DNS resolvers probed with their interface scope, resolver-probe failures capped at Info when HTTP proves names resolve.
- **Doctor mode**: `octomon --doctor [--observe SECS] [--speedtest] [--json]` — analysis + location normals + measurements + events, redacted by default (safe to paste into ISP tickets; `--full` for local use), exit codes 0/1/3 for scripting.

## Cross-platform notes for testing

- Linux/Windows: the ICMPv6 client, per-target web prober, HTTP endpoint table (Ubuntu/Microsoft native endpoints), link-lost detection, and DNS scope-id path are the areas most worth exercising — all were developed and live-tested on macOS only.
- Wi-Fi SSID sourcing differs per platform; the fingerprint falls back to gateway MAC wherever SSID is unavailable.

## Testing

- 120 unit/render tests passing, clippy clean.
- Live-tested on macOS: home Wi-Fi, iPhone 5G hotspot (v6-only carrier — found and fixed the ICMPv6, link-local DNS and gatewayless-fingerprint issues), Wi-Fi off/on (link-lost events + auto reset), `--doctor` text and JSON runs against the real network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)