### PR TITLE
Calm the latency-inflation and single-packet-loss findings

### DIFF
--- a/src/collectors/dns.rs
+++ b/src/collectors/dns.rs
@@ -29,14 +29,7 @@ pub async fn run(state: Arc<Mutex<AppState>>, cfg: Config) {
         // when the network does, or when a VPN installs its own proxy.
         let (servers, scope): (Vec<IpAddr>, u32) = {
             let s = state.lock().unwrap();
-            (
-                s.netinfo
-                    .dns
-                    .iter()
-                    .filter_map(|d| d.parse::<IpAddr>().ok())
-                    .collect(),
-                s.netinfo.iface_index,
-            )
+            (canonical_servers(&s.netinfo.dns), s.netinfo.iface_index)
         };
         if servers.is_empty() {
             state.lock().unwrap().dns.clear();
@@ -83,14 +76,33 @@ pub async fn run(state: Arc<Mutex<AppState>>, cfg: Config) {
 
         // Forget resolvers that dropped out of the configuration.
         let mut s = state.lock().unwrap();
-        let live: Vec<IpAddr> = s
-            .netinfo
-            .dns
-            .iter()
-            .filter_map(|d| d.parse::<IpAddr>().ok())
-            .collect();
+        let live = canonical_servers(&s.netinfo.dns);
         s.dns.retain(|p| live.contains(&p.server));
     }
+}
+
+/// The interface's resolver list as probeable addresses: IPv4-mapped IPv6
+/// forms (`::ffff:127.0.2.2` — Windows DNS filters register both spellings)
+/// unmap to their embedded IPv4, and the resulting duplicates collapse, so
+/// two real resolvers don't render as four scary rows.
+fn canonical_servers(configured: &[String]) -> Vec<IpAddr> {
+    let mut seen = Vec::new();
+    for d in configured {
+        let Ok(addr) = d.parse::<IpAddr>() else {
+            continue;
+        };
+        let addr = match addr {
+            IpAddr::V6(v6) => match v6.to_ipv4_mapped() {
+                Some(v4) => IpAddr::V4(v4),
+                None => IpAddr::V6(v6),
+            },
+            v4 => v4,
+        };
+        if !seen.contains(&addr) {
+            seen.push(addr);
+        }
+    }
+    seen
 }
 
 /// Send one A query and time the answer. `scope` is the interface index a
@@ -128,8 +140,19 @@ async fn query(
     parse_response(id, &buf[..read])
 }
 
+/// Compact reason for a probe failure. OS error strings are long and get
+/// clipped mid-word ("not valid in it"); the kind carries the meaning.
 fn short(e: &std::io::Error) -> String {
-    e.to_string().chars().take(40).collect()
+    use std::io::ErrorKind;
+    match e.kind() {
+        ErrorKind::ConnectionRefused => "refused".to_string(),
+        ErrorKind::ConnectionReset => "connection reset".to_string(),
+        ErrorKind::AddrNotAvailable => "address not usable".to_string(),
+        ErrorKind::NetworkUnreachable | ErrorKind::HostUnreachable => "unreachable".to_string(),
+        ErrorKind::PermissionDenied => "permission denied".to_string(),
+        ErrorKind::TimedOut => "timeout".to_string(),
+        _ => e.to_string().chars().take(28).collect(),
+    }
 }
 
 /// A resolver-probe name has to be a valid QNAME; fall back rather than send a
@@ -223,6 +246,48 @@ mod tests {
         assert_eq!(parse_response(0x1234, &servfail), Err("SERVFAIL".into()));
 
         assert!(parse_response(0x1234, &[0u8; 4]).is_err());
+    }
+
+    /// The Windows DNS-filter shape: `::ffff:127.0.2.2` alongside `127.0.2.2`.
+    /// The mapped form must unmap (a v6 socket can't reach it) and the
+    /// duplicates must collapse — two real resolvers, not four scary rows.
+    #[test]
+    fn mapped_v6_resolvers_unmap_and_deduplicate() {
+        let configured: Vec<String> = [
+            "::ffff:127.0.2.2",
+            "::ffff:127.0.2.3",
+            "127.0.2.2",
+            "127.0.2.3",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+        let servers = canonical_servers(&configured);
+        assert_eq!(servers.len(), 2);
+        assert!(servers.iter().all(|a| a.is_ipv4() && a.is_loopback()));
+
+        // Real v6 resolvers stay v6; order is preserved.
+        let mixed: Vec<String> = ["2606:4700:4700::1111", "1.1.1.1"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let servers = canonical_servers(&mixed);
+        assert_eq!(servers.len(), 2);
+        assert!(servers[0].is_ipv6());
+    }
+
+    #[test]
+    fn failure_reasons_are_compact_words_not_clipped_prose() {
+        use std::io::{Error, ErrorKind};
+        assert_eq!(
+            short(&Error::from(ErrorKind::ConnectionReset)),
+            "connection reset"
+        );
+        assert_eq!(
+            short(&Error::from(ErrorKind::AddrNotAvailable)),
+            "address not usable"
+        );
+        assert_eq!(short(&Error::from(ErrorKind::ConnectionRefused)), "refused");
     }
 
     #[test]

--- a/src/verdict.rs
+++ b/src/verdict.rs
@@ -591,12 +591,20 @@ pub fn evaluate(s: &AppState) -> Triage {
         if n_fail == probes.len() && names_resolve {
             let mut evidence = evidence.clone();
             evidence.push("HTTP check fetched a hostname fine — resolution itself works".into());
+            // Loopback resolvers are a DNS filter/proxy on this machine
+            // (AdGuard-style 127.0.2.x is the classic signature): it answers
+            // the OS but not necessarily octomon's probes. Name the situation
+            // rather than reporting a generic failure.
+            let all_local = probes.iter().all(|p| p.server.is_loopback());
             findings.push(Finding {
                 cause: Cause::Dns,
                 severity: Severity::Info,
                 confidence: Confidence::Weak,
-                summary: "resolver probes blocked on this network — names still resolve"
-                    .to_string(),
+                summary: if all_local {
+                    "a local DNS proxy handles resolution — probes not answerable".to_string()
+                } else {
+                    "resolver probes blocked on this network — names still resolve".to_string()
+                },
                 evidence,
                 subject: String::new(),
             });
@@ -1675,6 +1683,23 @@ mod tests {
         assert_eq!(f.severity, Severity::Down);
         // The anchors-fine contrast is the whole point.
         assert_eq!(f.confidence, Confidence::Strong);
+    }
+
+    /// The Windows DNS-filter lesson: loopback resolvers (127.0.2.x) that
+    /// answer the OS but not octomon's probes get named as what they are.
+    #[test]
+    fn loopback_resolvers_are_named_a_local_proxy() {
+        let mut s = healthy_state();
+        let mut p = crate::app::DnsProbe::new(IpAddr::V4(Ipv4Addr::new(127, 0, 2, 2)));
+        p.sent = 10;
+        p.ok = 0;
+        p.status = "connection reset".into();
+        s.dns = vec![p];
+        s.http.v4 = crate::app::FamilyProbe::Ok(30.0);
+        let t = evaluate(&s);
+        let f = t.findings.iter().find(|f| f.cause == Cause::Dns).unwrap();
+        assert_eq!(f.severity, Severity::Info);
+        assert!(f.summary.contains("local DNS proxy"), "{}", f.summary);
     }
 
     /// The hotspot lesson: a carrier network handed out a link-local resolver

--- a/src/verdict.rs
+++ b/src/verdict.rs
@@ -48,10 +48,17 @@ pub mod thresholds {
     pub const RECENT: usize = 20;
     /// Below this many outcomes a probe has no opinion, only noise.
     pub const MIN_SAMPLES: usize = 5;
-    /// RTT counts as inflated above `max(factor × idle floor, this floor)` —
-    /// the absolute floor keeps a 1 ms → 4 ms gateway from reading as a fault.
-    pub const RTT_INFLATED_FLOOR_MS: f64 = 30.0;
+    /// RTT counts as inflated above `max(factor × idle floor, this floor)`.
+    /// The absolute floor carries most of the weight: Wi-Fi gateways with a
+    /// 2 ms idle floor routinely drift into the 30s on a *good* network
+    /// (power save, airtime scheduling), so anything below ~60 ms of mean is
+    /// weather, not a finding.
+    pub const RTT_INFLATED_FLOOR_MS: f64 = 60.0;
     pub const RTT_INFLATED_FACTOR: f64 = 3.0;
+    /// A "bad" loss reading needs at least this many lost packets in the
+    /// recent window — 1 of 20 is exactly LOSS_BAD_PCT, and one dropped ping
+    /// is not an outage.
+    pub const LOSS_MIN_LOST: usize = 2;
     /// A finding raises when present in ≥ RAISE_HITS of the last RAISE_WINDOW
     /// ticks, and clears after CLEAR_TICKS consecutive quiet ticks.
     pub const RAISE_HITS: usize = 4;
@@ -288,7 +295,14 @@ fn probe_health(t: &TargetStat) -> Health {
         return Health::NoData;
     }
     let loss = t.recent_loss_pct(th::RECENT);
-    if loss >= th::LOSS_BAD_PCT {
+    let lost = t
+        .window
+        .iter()
+        .rev()
+        .take(th::RECENT)
+        .filter(|ok| !**ok)
+        .count();
+    if loss >= th::LOSS_BAD_PCT && lost >= th::LOSS_MIN_LOST {
         return Health::Bad;
     }
     if loss >= th::LOSS_WARN_PCT || inflated(t) {
@@ -379,7 +393,16 @@ pub fn evaluate(s: &AppState) -> Triage {
     // --- gateway / LAN ---
     if let Some(g) = gw {
         let loss = g.recent_loss_pct(th::RECENT);
-        let raise = gw_health == Health::Bad || (gw_health != Health::NoData && inflated(g));
+        // An established baseline gets a veto over the *inflation* claim: on a
+        // network whose learned normal already sits near the current reading,
+        // absolute thresholds are the wrong judge and would flap all day.
+        // Loss-based raises are never vetoed — packets don't have a "normal".
+        let baseline_says_normal = baseline
+            .and_then(|b| b.gateway_ms)
+            .zip(g.stats(th::RECENT).mean)
+            .is_some_and(|(normal, cur)| !crate::baseline::well_above(cur, normal));
+        let raise = gw_health == Health::Bad
+            || (gw_health != Health::NoData && inflated(g) && !baseline_says_normal);
         if raise {
             let severity = if loss >= th::LOSS_DOWN_PCT {
                 Severity::Down
@@ -1722,6 +1745,71 @@ mod tests {
         assert!(!c.contains(&Cause::WebTarget));
     }
 
+    /// The Unifi lesson, part 1: one dropped ping in a 20-sample window is 5%
+    /// — exactly the "bad" threshold — and produced "Google degraded" blips
+    /// all afternoon on a healthy network. One packet is not an outage.
+    #[test]
+    fn one_lost_packet_is_not_a_finding() {
+        let mut s = healthy_state();
+        let google = s.targets.iter_mut().find(|t| t.label == "Google").unwrap();
+        google.record_loss();
+        assert!(
+            evaluate(&s).findings.is_empty(),
+            "single packet blip must stay quiet"
+        );
+        // Two lost packets is a pattern.
+        let google = s.targets.iter_mut().find(|t| t.label == "Google").unwrap();
+        google.record_loss();
+        assert!(!evaluate(&s).findings.is_empty());
+    }
+
+    /// The Unifi lesson, part 2: a Wi-Fi gateway with a 2ms idle floor drifts
+    /// into the 30s constantly on a *good* network — that is weather, and it
+    /// flapped "latency inflated" every minute or two.
+    #[test]
+    fn wifi_weather_in_the_thirties_is_not_inflation() {
+        let mut s = healthy_state();
+        let gw = s.targets.iter_mut().find(|t| t.discovered).unwrap();
+        gw.reset();
+        for _ in 0..5 {
+            gw.record_reply(2.0);
+        }
+        for _ in 0..20 {
+            gw.record_reply(34.0);
+        }
+        assert!(
+            !causes(&evaluate(&s)).contains(&Cause::GatewayLan),
+            "34ms mean on a 2ms floor is below the inflation floor"
+        );
+    }
+
+    /// The Unifi lesson, part 3: where an established baseline says the
+    /// current reading is normal for this network, the absolute inflation
+    /// rule loses the argument. Loss keeps its vote regardless.
+    #[test]
+    fn the_baseline_can_veto_an_inflation_claim() {
+        let mut s = healthy_state();
+        let gw = s.targets.iter_mut().find(|t| t.discovered).unwrap();
+        gw.reset();
+        for _ in 0..5 {
+            gw.record_reply(5.0);
+        }
+        for _ in 0..20 {
+            gw.record_reply(70.0); // above the absolute floor: would raise
+        }
+        assert!(causes(&evaluate(&s)).contains(&Cause::GatewayLan));
+
+        // Same readings, but this network's learned normal is ~65ms (a slow
+        // powerline backhaul, say): not a finding, just how it is here.
+        s.baseline = Some(crate::baseline::Baseline {
+            label: "SlowNet".into(),
+            samples: 10,
+            gateway_ms: Some(65.0),
+            ..Default::default()
+        });
+        assert!(!causes(&evaluate(&s)).contains(&Cause::GatewayLan));
+    }
+
     /// The mandatory wrongness test: simultaneous causes must BOTH be reported,
     /// with the network cause ranked above the machine caveat.
     #[test]
@@ -1856,7 +1944,7 @@ mod tests {
     #[test]
     fn baseline_turns_absolute_numbers_into_vs_normal() {
         let mut s = healthy_state();
-        // Gateway idle floor 5ms, now sitting at 45ms — inflated in absolute
+        // Gateway idle floor 5ms, now sitting at 70ms — inflated in absolute
         // terms AND way above this network's learned normal.
         let gw = s.targets.iter_mut().find(|t| t.discovered).unwrap();
         gw.reset();
@@ -1864,7 +1952,7 @@ mod tests {
             gw.record_reply(5.0);
         }
         for _ in 0..20 {
-            gw.record_reply(45.0);
+            gw.record_reply(70.0);
         }
         s.baseline = Some(crate::baseline::Baseline {
             label: "HomeNet".into(),


### PR DESCRIPTION
Post-v0.5.0 sensitivity fix from field testing on a healthy Unifi network: the analysis flapped "gateway latency inflated (34ms vs 2ms idle)" every minute or two, and single dropped pings (1 of 20 = exactly the 5% threshold) produced "degraded" blips.

- Inflation floor 30ms → 60ms (Wi-Fi gateways drift into the 30s on good networks — that's weather, not a finding)
- An established baseline now vetoes inflation claims when the reading is normal for this network; previously it only adjusted confidence
- "Bad" loss needs ≥2 lost packets in the recent window

Three regression tests named after the field scenario; 124 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)