### PR TITLE
v0.6.1: native TLS roots, relative latency colours, locations rename, testing fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,6 +342,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -924,6 +934,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1649,6 +1660,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2216,6 +2233,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -2292,6 +2310,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2334,10 +2364,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -2863,6 +2925,7 @@ dependencies = [
  "futures-util",
  "log",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1619,7 +1619,7 @@ dependencies = [
 
 [[package]]
 name = "octomon"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,13 +33,17 @@ directories = "6.0.0"
 futures-util = "0.3.33"
 netdev = "0.46.0"
 ratatui = "0.30.2"
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream", "http2"] }
+# Both root stores: Mozilla's bundled set, and the OS store — which is where a
+# corporate / Zero-Trust TLS-inspection root (Cloudflare WARP with Gateway,
+# Zscaler…) lives. With only the bundle, every HTTPS check fails behind such a
+# proxy while the browser, trusting the OS store, is fine.
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-webpki-roots", "rustls-tls-native-roots", "stream", "http2"] }
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"
 surge-ping = "0.9.0"
 sysinfo = "0.39.6"
 tokio = { version = "1.53.1", features = ["full"] }
-tokio-tungstenite = { version = "0.30.0", default-features = false, features = ["connect", "rustls-tls-webpki-roots"] }
+tokio-tungstenite = { version = "0.30.0", default-features = false, features = ["connect", "rustls-tls-webpki-roots", "rustls-tls-native-roots"] }
 toml = "1.1.4"
 tracing = "0.1.44"
 tracing-subscriber = "0.3.23"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "octomon"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 description = "Btop-style terminal network monitor: latency, bandwidth, and Wi-Fi signal"
 repository = "https://github.com/securitypedant/octomon"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # octomon
 
-**A `btop`-style terminal dashboard for your network.** Think `btop`, `trippy`, and
-`bandwhich` in a single view — so you can tell at a glance whether it's the
-network, the Wi-Fi, the ISP, or your own machine that's misbehaving.
+**A `btop`-style terminal dashboard for your network.** I got sick of having
+to use multiple tools to diagnose network issues, so I built this. Think `btop`,
+`trippy`, and `bandwhich` in a single view, so you can tell at a glance 
+whether it's the network, the Wi-Fi, the ISP, or your own machine that's the problem.
 
 [![CI](https://github.com/securitypedant/octomon/actions/workflows/ci.yml/badge.svg)](https://github.com/securitypedant/octomon/actions/workflows/ci.yml)
 [![crates.io](https://img.shields.io/crates/v/octomon.svg)](https://crates.io/crates/octomon)

--- a/src/app.rs
+++ b/src/app.rs
@@ -1634,6 +1634,10 @@ pub struct AppState {
     pub bw_col: usize,
     /// Active sort of top talkers: (column, descending). None = default order.
     pub bw_sort: Option<(usize, bool)>,
+    /// The other talkers table's sort and column cursor, parked while this
+    /// one is shown — so each table keeps the order you gave it across `n`.
+    pub bw_sort_other: Option<(usize, bool)>,
+    pub bw_col_other: usize,
 
     // --- Connection Quality interaction ---
     /// Cursor over the target list (Quality panel).
@@ -1835,6 +1839,8 @@ impl AppState {
             proc_status: ProcStatus::Probing,
             bw_col: 1,
             bw_sort: None,
+            bw_sort_other: None,
+            bw_col_other: 1,
             selected: 0,
             graph_target: 0,
             window_secs: 60,

--- a/src/app.rs
+++ b/src/app.rs
@@ -1477,6 +1477,8 @@ pub enum InputMode {
     AddTarget,
     /// Typing a name for the current network ("Home", "Office").
     NameNetwork,
+    /// Typing a name for the location selected in the [L] overlay.
+    RenameLocation,
 }
 
 /// Which full-screen overlay is up, if any. One at a time; the order here is
@@ -1698,6 +1700,8 @@ pub struct AppState {
     /// Stored locations for the [L] overlay: (fingerprint key, baseline),
     /// loaded from disk when the overlay opens. `None` = still loading.
     pub locations: Option<Vec<(String, crate::baseline::Baseline)>>,
+    /// (key, auto label) of the location being renamed from the overlay.
+    pub rename_target: Option<(String, String)>,
     /// Scroll offset into the locations list.
     pub locations_sel: usize,
     /// Session timeline of state transitions (oldest → newest), capped.
@@ -1868,6 +1872,7 @@ impl AppState {
             baseline_key: None,
             explainer_pending: false,
             locations: None,
+            rename_target: None,
             locations_sel: 0,
             events: VecDeque::new(),
             events_total: 0,
@@ -2022,6 +2027,22 @@ impl AppState {
         });
     }
 
+    /// The locations as the overlay lists them: what was on disk when it
+    /// opened, plus the network we are on *now* if it isn't there yet — a
+    /// baseline is only written after its first healthy minute, and the
+    /// overlay may be open across a network change. The live one goes first.
+    /// The cursor and rename use the same list, so indices agree.
+    pub fn locations_view(&self) -> Option<Vec<(String, crate::baseline::Baseline)>> {
+        let all = self.locations.as_ref()?;
+        let mut v = all.clone();
+        if let (Some(key), Some(b)) = (&self.baseline_key, &self.baseline)
+            && !v.iter().any(|(k, _)| k == key)
+        {
+            v.insert(0, (key.clone(), b.clone()));
+        }
+        Some(v)
+    }
+
     /// This network's incident summary over the standard window, when the
     /// network is known.
     pub fn history_summary(&self) -> Option<crate::history::Summary> {
@@ -2085,12 +2106,23 @@ impl AppState {
             && self.sub_pane == SubPane::Primary
     }
 
+    /// The sort that applies to `view`: the live one when it is the shown
+    /// table, the parked one otherwise — so when both tables are drawn side
+    /// by side, each keeps the order it was given.
+    pub fn sort_for(&self, view: BwView) -> Option<(usize, bool)> {
+        if self.bw_view == view {
+            self.bw_sort
+        } else {
+            self.bw_sort_other
+        }
+    }
+
     /// Indices into `processes` in display order: the collector's ranking by
     /// session total unless a column sort is active. Shared by the renderer
     /// and the cursor, so ↑/↓ walk the rows as drawn.
     pub fn process_order(&self) -> Vec<usize> {
         let mut order: Vec<usize> = (0..self.processes.len()).collect();
-        let Some((col, desc)) = self.bw_sort.filter(|_| self.bw_view == BwView::Processes) else {
+        let Some((col, desc)) = self.sort_for(BwView::Processes) else {
             return order;
         };
         order.sort_by(|&i, &j| {
@@ -2112,7 +2144,7 @@ impl AppState {
     /// Indices into `remotes` in display order; see [`Self::process_order`].
     pub fn remote_order(&self) -> Vec<usize> {
         let mut order: Vec<usize> = (0..self.remotes.len()).collect();
-        let Some((col, desc)) = self.bw_sort.filter(|_| self.bw_view == BwView::Remotes) else {
+        let Some((col, desc)) = self.sort_for(BwView::Remotes) else {
             return order;
         };
         order.sort_by(|&i, &j| {

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -32,6 +32,11 @@ pub struct Baseline {
     /// User-given name ("Home", "Office"), set with [N].
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+    /// How the machine was attached when this was learned ("Wi-Fi",
+    /// "Ethernet (wired)") — the same LAN over a cable and over the radio is
+    /// two different normals, and two entries, so this tells them apart.
+    #[serde(default)]
+    pub medium: String,
     /// Healthy folds so far — confidence in the baseline itself.
     pub samples: u32,
     pub gateway_ms: Option<f64>,
@@ -56,8 +61,9 @@ impl Baseline {
 }
 
 /// One minute's healthy aggregates, computed under the state lock.
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Default)]
 pub struct Sample {
+    pub medium: String,
     pub gateway_ms: Option<f64>,
     pub gateway_p95_ms: Option<f64>,
     pub anchor_ms: Option<f64>,
@@ -96,6 +102,7 @@ impl Sample {
         let dns_ms = (!dns.is_empty()).then(|| dns.iter().sum::<f64>() / dns.len() as f64);
         let rssi_dbm = s.signal.present.then_some(s.signal.rssi_dbm as f64);
         Sample {
+            medium: s.netinfo.medium.label().to_string(),
             gateway_ms,
             gateway_p95_ms,
             anchor_ms,
@@ -116,6 +123,9 @@ fn ewma(prev: Option<f64>, new: Option<f64>) -> Option<f64> {
 impl Baseline {
     /// Fold one healthy minute in.
     pub fn fold(&mut self, sample: Sample) {
+        if !sample.medium.is_empty() {
+            self.medium = sample.medium;
+        }
         self.gateway_ms = ewma(self.gateway_ms, sample.gateway_ms);
         self.gateway_p95_ms = ewma(self.gateway_p95_ms, sample.gateway_p95_ms);
         self.anchor_ms = ewma(self.anchor_ms, sample.anchor_ms);

--- a/src/collectors/resolve.rs
+++ b/src/collectors/resolve.rs
@@ -22,7 +22,12 @@ use crate::app::AppState;
 
 const PERIODIC: Duration = Duration::from_secs(60);
 
-pub async fn run(state: Arc<Mutex<AppState>>, changed: Arc<Notify>) {
+pub async fn run(
+    state: Arc<Mutex<AppState>>,
+    clients: crate::collectors::ping::Clients,
+    cfg: crate::config::Config,
+    changed: Arc<Notify>,
+) {
     let mut ticker = tokio::time::interval(PERIODIC);
     ticker.tick().await; // the interval fires immediately; targets don't exist yet
     loop {
@@ -63,18 +68,36 @@ pub async fn run(state: Arc<Mutex<AppState>>, changed: Arc<Notify>) {
                 continue;
             }
 
-            let mut s = state.lock().unwrap();
-            let Some(t) = s.targets.iter_mut().find(|t| t.id == id) else {
-                continue;
+            let monitored = {
+                let mut s = state.lock().unwrap();
+                let Some(t) = s.targets.iter_mut().find(|t| t.id == id) else {
+                    continue;
+                };
+                t.addr = new; // the ping task notices and rebinds
+                t.reset();
+                let message = format!("{host} → {new} (was {current}) — stats reset");
+                s.push_event(
+                    crate::verdict::Severity::Info,
+                    crate::app::EventCategory::Network,
+                    message,
+                );
+                // A path monitor on the old address would quietly keep probing
+                // a host the target no longer points at — two different hosts
+                // under one name on screen.
+                s.hop_monitor
+                    .as_ref()
+                    .filter(|m| m.dest == current)
+                    .map(|m| m.target.split(" (").next().unwrap_or(&m.target).to_string())
             };
-            t.addr = new; // the ping task notices and rebinds
-            t.reset();
-            let message = format!("{host} → {new} (was {current}) — stats reset");
-            s.push_event(
-                crate::verdict::Severity::Info,
-                crate::app::EventCategory::Network,
-                message,
-            );
+            if let Some(label) = monitored {
+                crate::collectors::hopmon::start(
+                    state.clone(),
+                    clients.clone(),
+                    cfg.clone(),
+                    new,
+                    label,
+                );
+            }
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -951,8 +951,9 @@ fn handle_key(ctx: &Ctx, key: KeyEvent) {
                     // Each table keeps its own sort and column cursor: swap
                     // them in and out rather than resetting.
                     if view != s.bw_view {
-                        std::mem::swap(&mut s.bw_sort, &mut s.bw_sort_other);
-                        std::mem::swap(&mut s.bw_col, &mut s.bw_col_other);
+                        let st: &mut AppState = &mut s;
+                        std::mem::swap(&mut st.bw_sort, &mut st.bw_sort_other);
+                        std::mem::swap(&mut st.bw_col, &mut st.bw_col_other);
                     }
                     s.bw_view = view;
                     s.sub_pane = pane;

--- a/src/main.rs
+++ b/src/main.rs
@@ -259,6 +259,8 @@ async fn main() -> Result<()> {
     tokio::spawn(collectors::web::run(state.clone()));
     tokio::spawn(collectors::resolve::run(
         state.clone(),
+        ping_clients.clone(),
+        cfg.clone(),
         network_changed.clone(),
     ));
     if !cli.no_speedtest {
@@ -680,6 +682,39 @@ fn handle_key(ctx: &Ctx, key: KeyEvent) {
             },
 
             // --- modal text entry: naming the current network ---
+            InputMode::RenameLocation => match key.code {
+                KeyCode::Enter => {
+                    let name = s.input_buffer.trim().to_string();
+                    s.input_mode = InputMode::Normal;
+                    s.input_buffer.clear();
+                    if let Some((key, label)) = s.rename_target.take() {
+                        let new_name = (!name.is_empty()).then(|| name.clone());
+                        // Update what is on screen at once; the file write
+                        // happens off the key path.
+                        if let Some(all) = s.locations.as_mut()
+                            && let Some((_, b)) = all.iter_mut().find(|(k, _)| *k == key)
+                        {
+                            b.name = new_name.clone();
+                        }
+                        if s.baseline_key.as_deref() == Some(key.as_str())
+                            && let Some(b) = s.baseline.as_mut()
+                        {
+                            b.name = new_name;
+                        }
+                        side = Side::NameNetwork { key, label, name };
+                    }
+                }
+                KeyCode::Esc => {
+                    s.input_mode = InputMode::Normal;
+                    s.input_buffer.clear();
+                    s.rename_target = None;
+                }
+                KeyCode::Backspace => {
+                    s.input_buffer.pop();
+                }
+                KeyCode::Char(c) if s.input_buffer.len() < 40 => s.input_buffer.push(c),
+                _ => {}
+            },
             InputMode::NameNetwork => match key.code {
                 KeyCode::Enter => {
                     let name = s.input_buffer.trim().to_string();
@@ -815,6 +850,19 @@ fn handle_key(ctx: &Ctx, key: KeyEvent) {
                     }
                 }
                 // Scroll the locations list.
+                // Rename the selected location — any of them, not just the
+                // current network; a name given on the wrong day is common.
+                KeyCode::Enter | KeyCode::Char('N') if s.overlay == Overlay::Locations => {
+                    let picked = s
+                        .locations_view()
+                        .and_then(|all| all.get(s.locations_sel).cloned())
+                        .map(|(key, b)| (key, b.label.clone(), b.name.clone()));
+                    if let Some((key, label, name)) = picked {
+                        s.rename_target = Some((key, label));
+                        s.input_buffer = name.unwrap_or_default();
+                        s.input_mode = InputMode::RenameLocation;
+                    }
+                }
                 KeyCode::Up | KeyCode::Char('k') if s.overlay == Overlay::Locations => {
                     s.locations_sel = s.locations_sel.saturating_sub(1);
                 }
@@ -826,8 +874,7 @@ fn handle_key(ctx: &Ctx, key: KeyEvent) {
                 {
                     let step = if key.code == KeyCode::PageDown { 10 } else { 1 };
                     let last = s
-                        .locations
-                        .as_ref()
+                        .locations_view()
                         .map(|l| l.len().saturating_sub(1))
                         .unwrap_or(0);
                     s.locations_sel = (s.locations_sel + step).min(last);
@@ -1491,7 +1538,16 @@ fn doctor_report(s: &AppState, full: bool) -> (String, i32) {
     // The location always prints, named or not — knowing WHERE the report was
     // taken (and how established its baseline is) is part of the diagnosis.
     if let Some(b) = s.baseline.as_ref() {
-        let _ = writeln!(out, "\n== NORMAL AT \"{}\" ==", b.display_name());
+        let _ = writeln!(
+            out,
+            "\n== NORMAL AT \"{}\"{} ==",
+            b.display_name(),
+            if b.medium.is_empty() {
+                String::new()
+            } else {
+                format!(" ({})", b.medium)
+            }
+        );
         let ms = |v: Option<f64>| {
             v.map(|x| format!("~{x:.0}ms"))
                 .unwrap_or_else(|| "—".into())
@@ -1627,6 +1683,7 @@ fn doctor_json(s: &AppState, full: bool) -> (String, i32) {
         "location": s.baseline.as_ref().map(|b| json!({
             "name": b.name,
             "label": b.label,
+            "medium": b.medium,
             "healthy_minutes": b.samples,
             "established": b.established(),
             "normal": {

--- a/src/main.rs
+++ b/src/main.rs
@@ -948,8 +948,11 @@ fn handle_key(ctx: &Ctx, key: KeyEvent) {
                         }
                         _ => (BwView::Processes, SubPane::Primary),
                     };
+                    // Each table keeps its own sort and column cursor: swap
+                    // them in and out rather than resetting.
                     if view != s.bw_view {
-                        s.bw_sort = None;
+                        std::mem::swap(&mut s.bw_sort, &mut s.bw_sort_other);
+                        std::mem::swap(&mut s.bw_col, &mut s.bw_col_other);
                     }
                     s.bw_view = view;
                     s.sub_pane = pane;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -313,19 +313,17 @@ fn wrap_words(text: &str, width: usize) -> Vec<String> {
 /// Every stored network location with its learned baseline: what "normal"
 /// means at each place this machine has been.
 fn locations_overlay(f: &mut Frame, s: &AppState, area: Rect) {
-    let w = 84u16.min(area.width);
     let h = (area.height * 4 / 5).max(8.min(area.height));
-    let rect = Rect {
-        x: area.x + (area.width.saturating_sub(w)) / 2,
-        y: area.y + (area.height.saturating_sub(h)) / 2,
-        width: w,
-        height: h,
-    };
     // Three lines per location (name, stats, history).
-    let visible = (rect.height.saturating_sub(2) as usize) / 3;
+    let visible = (h.saturating_sub(2) as usize) / 3;
 
     let mut lines: Vec<Line> = Vec::new();
-    match &s.locations {
+    // The list is what is on disk when the overlay opened, plus the network
+    // we are on *now* if it isn't there yet — a baseline is only written
+    // after its first healthy minute, and the overlay may be open across a
+    // network change. Shown first, as "learning", rather than missing.
+    let merged = s.locations_view();
+    match &merged {
         None => lines.push(Line::from(Span::styled(
             "loading…",
             Style::new().fg(Color::DarkGray),
@@ -337,24 +335,48 @@ fn locations_overlay(f: &mut Frame, s: &AppState, area: Rect) {
             )));
         }
         Some(all) => {
-            // Scroll only when there is somewhere to scroll to: with the list
-            // fully visible the offset stays pinned at zero.
+            // `locations_sel` is the cursor; scroll just enough to keep it on
+            // screen, and only when there is somewhere to scroll to.
+            let sel = s.locations_sel.min(all.len().saturating_sub(1));
             let max_first = all.len().saturating_sub(visible.max(1));
-            let first = s.locations_sel.min(max_first);
+            let first = sel.saturating_sub(visible.max(1) - 1).min(max_first);
             let ms = |v: Option<f64>| {
                 v.map(|x| format!("~{x:.0}ms"))
                     .unwrap_or_else(|| "—".into())
             };
-            for (key, b) in all.iter().skip(first).take(visible.max(1)) {
+            for (i, (key, b)) in all.iter().enumerate().skip(first).take(visible.max(1)) {
                 let current = s.baseline_key.as_deref() == Some(key.as_str());
+                let selected = i == sel;
+                let name_style = if selected {
+                    Style::new().fg(Color::Black).bg(Color::Cyan).bold()
+                } else {
+                    Style::new().fg(Color::White).bold()
+                };
                 let mut name_row = vec![Span::styled(
-                    b.display_name().to_string(),
-                    Style::new().fg(Color::White).bold(),
+                    format!("{}{}", if selected { "▶ " } else { "  " }, b.display_name()),
+                    name_style,
                 )];
                 if b.name.is_some() && b.name.as_deref() != Some(&b.label) {
                     name_row.push(Span::styled(
                         format!("  ({})", b.label),
                         Style::new().fg(Color::DarkGray),
+                    ));
+                }
+                // The same LAN over Wi-Fi and over a cable is two entries;
+                // the medium is what tells them apart. The current network's
+                // entry may not have folded a minute yet — use the live
+                // medium for it rather than show nothing.
+                let medium = if !b.medium.is_empty() {
+                    b.medium.clone()
+                } else if current && s.netinfo.medium != LinkMedium::Unknown {
+                    s.netinfo.medium.label().to_string()
+                } else {
+                    String::new()
+                };
+                if !medium.is_empty() {
+                    name_row.push(Span::styled(
+                        format!("  · {medium}"),
+                        Style::new().fg(Color::Gray),
                     ));
                 }
                 if current {
@@ -396,7 +418,18 @@ fn locations_overlay(f: &mut Frame, s: &AppState, area: Rect) {
         }
     }
 
-    let total = s.locations.as_ref().map(Vec::len).unwrap_or(0);
+    // As wide as the widest line wants (the stats line carries a lot), up to
+    // nearly the terminal; never narrower than the footer hint needs.
+    let widest = lines.iter().map(|l| l.width()).max().unwrap_or(60) as u16;
+    let w = (widest + 4).clamp(84.min(area.width), area.width.saturating_sub(2).max(1));
+    let rect = Rect {
+        x: area.x + (area.width.saturating_sub(w)) / 2,
+        y: area.y + (area.height.saturating_sub(h)) / 2,
+        width: w,
+        height: h,
+    };
+
+    let total = merged.as_ref().map(Vec::len).unwrap_or(0);
     f.render_widget(Clear, rect);
     let outer = Block::bordered()
         .padding(Padding::new(1, 1, 0, 0))
@@ -405,7 +438,7 @@ fn locations_overlay(f: &mut Frame, s: &AppState, area: Rect) {
             Style::new().bold(),
         ))
         .title_bottom(Span::styled(
-            " ↑↓ scroll · [N] names the current network · press L or Esc to close ",
+            " ↑↓ select · Enter renames the selected location · press L or Esc to close ",
             Style::new().fg(Color::DarkGray),
         ))
         .border_style(Style::new().fg(Color::Cyan));
@@ -811,6 +844,12 @@ fn footer(f: &mut Frame, s: &AppState, area: Rect) {
             &s.input_buffer,
             "[Enter] save  [Esc] cancel",
         )
+    } else if s.input_mode == InputMode::RenameLocation {
+        input_line(
+            "rename location (blank clears): ",
+            &s.input_buffer,
+            "[Enter] save  [Esc] cancel",
+        )
     } else if let Some(n) = &s.notice {
         Line::from(Span::styled(
             format!(" {n}"),
@@ -1159,7 +1198,13 @@ fn quality_panel(f: &mut Frame, s: &AppState, area: Rect) {
         let t = &s.targets[i];
         let loss = t.loss_pct();
         let st = t.stats(n);
-        let color = latency_color(t.last_rtt_ms, loss);
+        // A mid-path router that never answers ICMP is not a fault — the
+        // analysis already treats it that way — so it reads dim, not red.
+        let color = if t.is_path_hop() && loss >= th::LOSS_DOWN_PCT {
+            Color::DarkGray
+        } else {
+            latency_color(t.last_rtt_ms, loss, crate::verdict::rtt_reference(t, s))
+        };
         let marker = if i == s.graph_target { "►" } else { "" };
         let mut style = Style::new().fg(color);
         if focused && i == s.selected {
@@ -1305,7 +1350,7 @@ fn web_graph(f: &mut Frame, s: &AppState, area: Rect) {
             Style::new().fg(Color::Green),
         ),
         WebStatus::NoService => Span::styled(
-            "no web service (connection refused)".to_string(),
+            "no web check — port 443 refused".to_string(),
             Style::new().fg(Color::DarkGray),
         ),
         WebStatus::Filtered => Span::styled(
@@ -1486,7 +1531,8 @@ fn hop_monitor_view(f: &mut Frame, s: &AppState, n: usize, area: Rect) {
             };
             let loss = stat.loss_pct();
             let st = stat.stats(n);
-            let mut style = Style::new().fg(latency_color(stat.last_rtt_ms, loss));
+            let mut style =
+                Style::new().fg(latency_color(stat.last_rtt_ms, loss, stat.min_ever_ms));
             if selected {
                 style = style
                     .bg(Color::Rgb(40, 40, 55))
@@ -1570,7 +1616,8 @@ fn hop_monitor_view(f: &mut Frame, s: &AppState, n: usize, area: Rect) {
                     .iter()
                     .zip(data.iter())
                     .map(|(&h, &raw)| {
-                        SparklineBar::from(h).style(Style::new().fg(rtt_color(raw as f64)))
+                        SparklineBar::from(h)
+                            .style(Style::new().fg(rtt_color(raw as f64, stat.min_ever_ms)))
                     })
                     .collect();
                 f.render_widget(
@@ -2217,9 +2264,6 @@ fn top_talkers_view(f: &mut Frame, s: &AppState, area: Rect, view: BwView) {
     if view == BwView::Remotes {
         return top_remotes(f, s, inner);
     }
-    // Only the active table (of the two shown side by side in full screen)
-    // carries the column cursor and sort.
-    let active = s.bw_view == BwView::Processes;
 
     // Session totals lead (that is what the table ranks by); the live rate and
     // health columns follow, and go first when the panel is narrow.
@@ -2227,7 +2271,7 @@ fn top_talkers_view(f: &mut Frame, s: &AppState, area: Rect, view: BwView) {
     const WIDTHS: [u16; 7] = [21, 7, 7, 7, 10, 5, 5];
     let ncols = fitting_columns(&WIDTHS, inner.width);
     let labels = ["name", "total", "↓", "↑", "now", "share", "retx"];
-    let header = talkers_header(s, &labels[..ncols], active);
+    let header = talkers_header(s, &labels[..ncols], BwView::Processes);
 
     // Rows as drawn (the sort, when one is active), scrolled to keep the
     // cursor in view, with a cue beside them when there is more.
@@ -2354,12 +2398,16 @@ fn fmt_now(bps: f64) -> Cell<'static> {
 
 /// Sortable header row for a talkers table: the column under the cursor is
 /// highlighted, the sorted column carries a direction arrow.
-fn talkers_header<'a>(s: &AppState, labels: &[&'a str], active: bool) -> Row<'a> {
-    let focused = active && s.focus == Panel::Bandwidth;
+fn talkers_header<'a>(s: &AppState, labels: &[&'a str], view: BwView) -> Row<'a> {
+    let active = s.bw_view == view;
+    // The column cursor belongs to the table that holds the row cursor —
+    // not while the speed-test history pane has it.
+    let focused = active && s.focus == Panel::Bandwidth && s.sub_pane == SubPane::Primary;
     Row::new(labels.iter().enumerate().map(|(i, l)| {
         let mut txt = (*l).to_string();
-        if let Some((c, desc)) = s.bw_sort
-            && active
+        // The arrow shows whichever sort this table is drawn in — the parked
+        // one too, when the other table is the active one.
+        if let Some((c, desc)) = s.sort_for(view)
             && c == i
         {
             txt.push(if desc { '▼' } else { '▲' });
@@ -2403,8 +2451,7 @@ fn top_remotes(f: &mut Frame, s: &AppState, area: Rect) {
     const WIDTHS: [u16; 7] = [24, 12, 7, 7, 7, 10, 5];
     let ncols = fitting_columns(&WIDTHS, area.width);
     let labels = ["remote", "process", "total", "↓", "↑", "now", "share"];
-    let active = s.bw_view == BwView::Remotes;
-    let header = talkers_header(s, &labels[..ncols], active);
+    let header = talkers_header(s, &labels[..ncols], BwView::Remotes);
 
     let order = s.remote_order();
     let cursor_on = s.selected_remote().is_some();
@@ -3718,13 +3765,14 @@ fn fmt_bytes(n: u64) -> String {
     }
 }
 
-/// Colour a single round-trip sample. Unlike [`latency_color`] this judges one
+/// Colour a single round-trip sample against the path's reference floor (see
+/// [`crate::verdict::rtt_grade`]). Unlike [`latency_color`] this judges one
 /// measurement in isolation, so a trace can show what each moment looked like.
-fn rtt_color(ms: f64) -> Color {
-    match ms {
-        v if v < th::RTT_WARN_MS => Color::Green,
-        v if v < th::RTT_BAD_MS => Color::Yellow,
-        _ => Color::Red,
+fn rtt_color(ms: f64, reference_ms: Option<f64>) -> Color {
+    match crate::verdict::rtt_grade(ms, reference_ms) {
+        crate::verdict::RttGrade::Good => Color::Green,
+        crate::verdict::RttGrade::Warn => Color::Yellow,
+        crate::verdict::RttGrade::Bad => Color::Red,
     }
 }
 
@@ -3735,7 +3783,9 @@ const SERIES_COLOR: Color = Color::Cyan;
 const P95_COLOR: Color = Color::Magenta;
 const JITTER_COLOR: Color = Color::LightBlue;
 
-fn latency_color(last: Option<f64>, loss: f64) -> Color {
+/// A target row's colour: loss first (absolute — packets have no "normal"),
+/// then the latest round trip against the path's own reference floor.
+fn latency_color(last: Option<f64>, loss: f64, reference_ms: Option<f64>) -> Color {
     if loss >= th::LOSS_BAD_PCT || last.is_none() {
         return Color::Red;
     }
@@ -3743,7 +3793,7 @@ fn latency_color(last: Option<f64>, loss: f64) -> Color {
         return Color::Yellow;
     }
     match last {
-        Some(ms) => rtt_color(ms),
+        Some(ms) => rtt_color(ms, reference_ms),
         None => Color::Red,
     }
 }
@@ -4509,8 +4559,13 @@ mod tests {
         // The spike still tops out, and colour comes from the raw value so a
         // floored-up sample is not miscoloured as slow.
         assert_eq!(heights.iter().copied().max().unwrap(), 240);
-        assert_eq!(rtt_color(14.0), Color::Green);
-        assert_eq!(rtt_color(240.0), Color::Red);
+        assert_eq!(rtt_color(14.0, None), Color::Green);
+        assert_eq!(rtt_color(240.0, None), Color::Red);
+        // Against a 160 ms floor (a VPN exit on another continent) the same
+        // 240 ms is within normal, and 600 ms is the problem.
+        assert_eq!(rtt_color(240.0, Some(160.0)), Color::Green);
+        assert_eq!(rtt_color(400.0, Some(160.0)), Color::Yellow);
+        assert_eq!(rtt_color(600.0, Some(160.0)), Color::Red);
     }
 
     /// A long target list must stay navigable when the path monitor squeezes it.

--- a/src/util.rs
+++ b/src/util.rs
@@ -55,9 +55,9 @@ pub async fn fetch_text_capped(
         .get(url)
         .send()
         .await
-        .map_err(|e| e.to_string())?
+        .map_err(|e| describe_error(&e))?
         .error_for_status()
-        .map_err(|e| e.to_string())?;
+        .map_err(|e| describe_error(&e))?;
     let buf = read_capped(resp, max_bytes).await?;
     String::from_utf8(buf).map_err(|_| "non-UTF-8 response".to_string())
 }

--- a/src/verdict.rs
+++ b/src/verdict.rs
@@ -355,6 +355,61 @@ fn probe_health(t: &TargetStat) -> Health {
     Health::Good
 }
 
+/// How one round-trip reading compares with what this path normally shows.
+/// The question the colour answers is "is this worse than it should be
+/// *here*", not "is this far away": 160 ms through a VPN exit on another
+/// continent is physics, and a 5 ms LAN gateway sitting at 40 ms is a fault.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum RttGrade {
+    Good,
+    Warn,
+    Bad,
+}
+
+/// Grade `ms` against `reference_ms`, the path's idle floor (its session
+/// minimum, lowered to the learned normal for this network when there is
+/// one). Relative bands — within 1.5× is fine, up to 3× is a caution, beyond
+/// is bad — with the old absolute thresholds kept as floors, so a LAN path
+/// with a 2 ms floor still reads yellow at 50 ms and red at 150 ms rather than
+/// at 3 ms and 6 ms. With no reference at all, the absolute scale stands.
+pub fn rtt_grade(ms: f64, reference_ms: Option<f64>) -> RttGrade {
+    let r = reference_ms.unwrap_or(0.0).max(0.0);
+    let good_max = (r * 1.5).max(th::RTT_WARN_MS);
+    let bad_min = (r * th::RTT_INFLATED_FACTOR).max(th::RTT_BAD_MS);
+    if ms <= good_max {
+        RttGrade::Good
+    } else if ms <= bad_min {
+        RttGrade::Warn
+    } else {
+        RttGrade::Bad
+    }
+}
+
+/// The reference floor for a target: its own idle minimum this session,
+/// lowered to this network's learned normal for that kind of target when a
+/// baseline is established — so a session that *starts* degraded still has
+/// something honest to be judged against.
+pub fn rtt_reference(t: &TargetStat, s: &AppState) -> Option<f64> {
+    let learned = s
+        .baseline
+        .as_ref()
+        .filter(|b| b.established())
+        .and_then(|b| {
+            if t.hop_ttl() == Some(1) {
+                b.gateway_ms
+            } else if !t.discovered {
+                b.anchor_ms
+            } else {
+                None
+            }
+        });
+    match (t.min_ever_ms, learned) {
+        (Some(m), Some(l)) => Some(m.min(l)),
+        (Some(m), None) => Some(m),
+        (None, l) => l,
+    }
+}
+
 /// Recent mean RTT well above the all-time idle floor.
 fn inflated(t: &TargetStat) -> bool {
     match (t.stats(th::RECENT).mean, t.min_ever_ms) {
@@ -1251,14 +1306,14 @@ pub fn evaluate(s: &AppState) -> Triage {
                     // Contrast: ping is fine while HTTP is not. Corroboration
                     // would be a second vantage point, which there isn't.
                     confidence: judge(true, false, false),
-                    summary: format!("{} web service not answering — ping still fine", t.label),
+                    summary: format!("web check to {} unanswered — ping still fine", t.label),
                     evidence: vec![
                         format!(
-                            "{} HTTP probes unanswered on a target that served HTTP before",
+                            "{} HTTPS HEAD probes in a row unanswered by a target that answered them before",
                             t.web.fails
                         ),
                         format!(
-                            "ICMP to {} still healthy ({:.0}% loss) — the service, not the path",
+                            "ICMP to {} still healthy ({:.0}% loss) — the web side, not the path",
                             t.addr,
                             t.recent_loss_pct(th::RECENT)
                         ),
@@ -1985,7 +2040,7 @@ pub fn checks(s: &AppState) -> Vec<Check> {
                 "DNS honesty",
                 RungStatus::Ok,
                 format!(
-                    "{} resolver{} answer NXDOMAIN for names that don't exist",
+                    "{} resolver{} say \"no such name\" honestly — none redirect typos",
                     judged.len(),
                     if judged.len() == 1 { "" } else { "s" }
                 ),
@@ -2920,6 +2975,40 @@ mod tests {
             .find(|f| f.cause == Cause::ClockSkew)
             .unwrap();
         assert_eq!(f.confidence, Confidence::Likely);
+    }
+
+    /// Colour and analysis share one question — worse than it should be
+    /// *here*? — so a far-away path is not red for being far away.
+    #[test]
+    fn rtt_grade_is_relative_with_absolute_floors() {
+        use RttGrade::*;
+        // No reference: the absolute scale.
+        assert_eq!(rtt_grade(40.0, None), Good);
+        assert_eq!(rtt_grade(100.0, None), Warn);
+        assert_eq!(rtt_grade(200.0, None), Bad);
+        // A 2 ms LAN gateway: the floors hold, so 40 ms is still fine and
+        // 160 ms still bad — not 3 ms and 6 ms.
+        assert_eq!(rtt_grade(40.0, Some(2.0)), Good);
+        assert_eq!(rtt_grade(100.0, Some(2.0)), Warn);
+        assert_eq!(rtt_grade(160.0, Some(2.0)), Bad);
+        // A 156 ms VPN exit: 170 is normal, 400 a caution, 600 bad.
+        assert_eq!(rtt_grade(170.0, Some(156.0)), Good);
+        assert_eq!(rtt_grade(400.0, Some(156.0)), Warn);
+        assert_eq!(rtt_grade(600.0, Some(156.0)), Bad);
+
+        // The reference is the session floor, lowered to the learned normal so
+        // a session that started degraded is still judged honestly.
+        let mut s = healthy_state();
+        let t = probe("x", [203, 0, 113, 5], 5, 0);
+        let mut t = t;
+        t.min_ever_ms = Some(150.0);
+        assert_eq!(rtt_reference(&t, &s), Some(150.0));
+        s.baseline = Some(crate::baseline::Baseline {
+            anchor_ms: Some(20.0),
+            samples: 40,
+            ..Default::default()
+        });
+        assert_eq!(rtt_reference(&t, &s), Some(20.0));
     }
 
     /// Wi-Fi with no signal sample yet is not measured, so it is not "ok".


### PR DESCRIPTION
Under Cloudflare WARP on the Windows VM, public-IP discovery failed against both endpoints while the browser worked. Most likely TLS inspection: the inspecting root lives in the OS store, which rustls with only the bundled webpki roots does not consult.

- reqwest / tokio-tungstenite: `rustls-tls-native-roots` alongside `rustls-tls-webpki-roots`.
- `fetch_text_capped` errors now carry the cause chain (so the checks block will say "certificate…" if this is it).

Verified: tests pass; live RDAP/NTP still fine; public IP discovered under WARP here (no inspection on this account).

🤖 Generated with [Claude Code](https://claude.com/claude-code)